### PR TITLE
Introduce tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+lib/js/bundle.js -diff

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ To build the JavaScript bundle _when files change_:
 
 `npm run dev`
 
+To run tests:
+
+`npm test`
+
 To lint the JavaScript:
 
 `npm run lint`

--- a/lib/js/bundle.js
+++ b/lib/js/bundle.js
@@ -4,6 +4,23 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.default = bindClearButton;
+function bindClearButton(options) {
+
+  options.btnClear.addEventListener('click', function () {
+    console.clear();
+    options.output.setValue('');
+    options.evalError.textContent = '';
+  });
+}
+
+},{}],2:[function(require,module,exports){
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = bindShortUrlButton;
 
 var _ramda = require('ramda');
 
@@ -23,16 +40,14 @@ var req = {
   longUrl: 'http://ramdajs.com/repl/'
 };
 
-var makeShortUrlBtn = document.getElementById('mkurl');
-
-var input = document.getElementById('urlout');
-
-var setValue = _ramda2.default.curry(function (data) {
-  input.value = data;
-  input.select();
+var setValue = _ramda2.default.curry(function (urlOut, data) {
+  urlOut.value = data;
+  urlOut.select();
 });
 
-var error = console.error.bind(console);
+var error = function error(err) {
+  return console.error(err);
+};
 
 var xhr = function xhr(url) {
   return new _ramdaFantasy.Future(function (reject, resolve) {
@@ -48,27 +63,39 @@ var xhr = function xhr(url) {
   });
 };
 
-var getResponse = _ramda2.default.compose(_ramda2.default.map(_sanctuary2.default.parseJson), _ramda2.default.map(_ramda2.default.path(['target', 'response'])), xhr);
+var getResponse = _ramda2.default.compose(_ramda2.default.map(_sanctuary2.default.parseJson), _ramda2.default.map(_ramda2.default.path(['target', 'responseText'])), xhr);
 
-var getShortUrl = _ramda2.default.map(_ramda2.default.compose(setValue, _ramda2.default.prop('id')));
+var getShortUrl = function getShortUrl(urlOut) {
+  return _ramda2.default.map(_ramda2.default.compose(setValue(urlOut), _ramda2.default.prop('id')));
+};
 
 var futureXhr = getResponse(apiUrl);
 
-exports.default = function () {
-  return makeShortUrlBtn.addEventListener('click', function () {
-    return futureXhr.fork(error, getShortUrl);
-  });
-};
+function bindShortUrlButton(options) {
 
-},{"ramda":462,"ramda-fantasy":450,"sanctuary":470}],2:[function(require,module,exports){
+  options.btnMakeShortUrl.addEventListener('click', function () {
+    futureXhr.fork(error, getShortUrl(options.urlOut));
+  });
+}
+
+},{"ramda":463,"ramda-fantasy":451,"sanctuary":471}],3:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-var consoleLogElement = document.querySelector('.console-log');
+
+var _ramda = require('ramda');
+
+var _ramda2 = _interopRequireDefault(_ramda);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
 var internals = {};
 var reporter = {};
+
+var consoleLogElement = undefined,
+    consoleRef = undefined;
 
 internals.buffer = [];
 
@@ -78,11 +105,11 @@ internals.flush = function flush() {
 
 internals.logMethods = ['log', 'info', 'debug'];
 
-internals.prepLogs = R.cond([[R.is(String), R.identity], [R.is(Function), R.toString], [R.T, JSON.stringify]]);
+internals.prepLogs = _ramda2.default.cond([[_ramda2.default.is(String), _ramda2.default.identity], [_ramda2.default.is(Function), _ramda2.default.toString], [_ramda2.default.T, JSON.stringify]]);
 
 internals.intercept = function (method) {
-  var original = console[method];
-  console[method] = function () {
+  var original = consoleRef[method];
+  consoleRef[method] = function () {
     for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
       args[_key] = arguments[_key];
     }
@@ -91,22 +118,25 @@ internals.intercept = function (method) {
       buf.push(internals.prepLogs(arg));
       return buf;
     }, internals.buffer);
-    original.apply(console, args);
+    original.apply(consoleRef, args);
     internals.flush();
   };
 };
 
 internals.clear = function () {
-  var consoleClear = console.clear;
-  console.clear = function () {
+  var consoleClear = consoleRef.clear;
+  consoleRef.clear = function () {
     internals.buffer = [];
     consoleLogElement.textContent = '';
-    consoleClear.call(console);
+    consoleClear.call(consoleRef);
   };
 };
 
-reporter.main = function () {
+reporter.main = function (options) {
+  consoleLogElement = options.consoleLogElement;
+  consoleRef = options.consoleRef;
   internals.clear();
+  internals.buffer = [];
   internals.logMethods.reduce(function (fn, method) {
     fn(method);
     return fn;
@@ -115,7 +145,7 @@ reporter.main = function () {
 
 exports.default = reporter;
 
-},{}],3:[function(require,module,exports){
+},{"ramda":463}],4:[function(require,module,exports){
 (function (global){
 "use strict";
 
@@ -141,12 +171,13 @@ R.forEach(function (x) {
 }, R.keys(R));
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],4:[function(require,module,exports){
+},{}],5:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.default = bindPrettyButton;
 
 var _prettyJs = require('pretty-js');
 
@@ -154,15 +185,13 @@ var _prettyJs2 = _interopRequireDefault(_prettyJs);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var prettyBtn = document.querySelector('.pretty-console');
-
-exports.default = function (output) {
-  prettyBtn.addEventListener('click', function prettify() {
-    output.setValue((0, _prettyJs2.default)(output.getValue()));
+function bindPrettyButton(options) {
+  options.btnPretty.addEventListener('click', function prettify() {
+    options.output.setValue((0, _prettyJs2.default)(options.output.getValue()));
   });
-};
+}
 
-},{"pretty-js":446}],5:[function(require,module,exports){
+},{"pretty-js":447}],6:[function(require,module,exports){
 'use strict';
 
 var _debounce = require('debounce');
@@ -172,6 +201,10 @@ var _debounce2 = _interopRequireDefault(_debounce);
 var _queryString = require('query-string');
 
 var _queryString2 = _interopRequireDefault(_queryString);
+
+var _clear = require('./clear');
+
+var _clear2 = _interopRequireDefault(_clear);
 
 var _logger = require('./logger');
 
@@ -242,10 +275,6 @@ var compile = function compile() {
   }
 };
 
-_logger2.default.main();
-
-(0, _googl2.default)();
-
 var debounceCompile = (0, _debounce2.default)(compile, 1000);
 
 var codeMirrorConfig = {
@@ -279,9 +308,31 @@ input.on('change', debounceCompile);
 
 var output = CodeMirror.fromTextArea(document.querySelector('.output'), outputConfig);
 
-(0, _reset2.default)(output);
+_logger2.default.main({
+  consoleLogElement: document.querySelector('.console-log'),
+  consoleRef: window.console
+});
 
-(0, _pretty2.default)(output);
+(0, _reset2.default)({
+  btnReset: document.getElementById('resetBtn'),
+  window: window
+});
+
+(0, _clear2.default)({
+  btnClear: document.querySelector('.clear-console'),
+  evalError: document.querySelector('pre.error'),
+  output: output
+});
+
+(0, _googl2.default)({
+  btnMakeShortUrl: document.getElementById('mkurl'),
+  urlOut: document.getElementById('urlout')
+});
+
+(0, _pretty2.default)({
+  btnPretty: document.querySelector('.pretty-console'),
+  output: output
+});
 
 // Get source code from 'code' params and paste it into editor
 // The 'code' param is actually located in a hash URL fragment,
@@ -291,34 +342,27 @@ if (code !== undefined) {
   input.setValue(code);
 }
 
-},{"./googl":1,"./logger":2,"./pretty":4,"./reset":6,"babel-core":11,"babel-preset-es2015":119,"babel-preset-stage-0":120,"debounce":314,"query-string":449}],6:[function(require,module,exports){
+},{"./clear":1,"./googl":2,"./logger":3,"./pretty":5,"./reset":7,"babel-core":12,"babel-preset-es2015":120,"babel-preset-stage-0":121,"debounce":315,"query-string":450}],7:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-var resetBtn = document.getElementById('resetBtn');
-var clearBtn = document.querySelector('.clear-console');
-var evalError = document.querySelector('pre.error');
+exports.default = bindResetButton;
+function bindResetButton(options) {
 
-exports.default = function (output) {
-  resetBtn.addEventListener('click', function () {
-    return window.location = '.';
+  options.btnReset.addEventListener('click', function () {
+    options.window.location = '.';
   });
-  clearBtn.addEventListener('click', function () {
-    console.clear();
-    output.setValue('');
-    evalError.textContent = '';
-  });
-};
+}
 
-},{}],7:[function(require,module,exports){
+},{}],8:[function(require,module,exports){
 'use strict';
 module.exports = function () {
 	return /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
 };
 
-},{}],8:[function(require,module,exports){
+},{}],9:[function(require,module,exports){
 'use strict';
 
 function assembleStyles () {
@@ -385,7 +429,7 @@ Object.defineProperty(module, 'exports', {
 	get: assembleStyles
 });
 
-},{}],9:[function(require,module,exports){
+},{}],10:[function(require,module,exports){
 // http://wiki.commonjs.org/wiki/Unit_Testing/1.0
 //
 // THIS IS NOT TESTED NOR LIKELY TO WORK OUTSIDE V8!
@@ -746,7 +790,7 @@ var objectKeys = Object.keys || function (obj) {
   return keys;
 };
 
-},{"util/":492}],10:[function(require,module,exports){
+},{"util/":493}],11:[function(require,module,exports){
 /* @flow */
 
 "use strict";
@@ -893,10 +937,10 @@ exports["default"] = function (rawLines /*: string*/, lineNumber /*: number*/, c
 };
 
 module.exports = exports["default"];
-},{"babel-runtime/helpers/interop-require-default":141,"chalk":231,"esutils":323,"js-tokens":332,"line-numbers":335,"repeating":469}],11:[function(require,module,exports){
+},{"babel-runtime/helpers/interop-require-default":142,"chalk":232,"esutils":324,"js-tokens":333,"line-numbers":336,"repeating":470}],12:[function(require,module,exports){
 module.exports = require("./lib/api/node.js");
 
-},{"./lib/api/node.js":12}],12:[function(require,module,exports){
+},{"./lib/api/node.js":13}],13:[function(require,module,exports){
 "use strict";
 
 var _interopRequireDefault = require("babel-runtime/helpers/interop-require-default")["default"];
@@ -1014,7 +1058,7 @@ function transformFileSync(filename /*: string*/) /*: string*/ {
   opts.filename = filename;
   return transform(_fs2["default"].readFileSync(filename, "utf8"), opts);
 }
-},{"../../package":31,"../tools/build-external-helpers":17,"../transformation/file":18,"../transformation/file/options/config":21,"../transformation/file/options/option-manager":23,"../transformation/pipeline":27,"../util":30,"babel-messages":66,"babel-runtime/helpers/interop-require":143,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-template":144,"babel-traverse":147,"babel-types":201,"fs":228,"lodash/lang/isFunction":418}],13:[function(require,module,exports){
+},{"../../package":32,"../tools/build-external-helpers":18,"../transformation/file":19,"../transformation/file/options/config":22,"../transformation/file/options/option-manager":24,"../transformation/pipeline":28,"../util":31,"babel-messages":67,"babel-runtime/helpers/interop-require":144,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-template":145,"babel-traverse":148,"babel-types":202,"fs":229,"lodash/lang/isFunction":419}],14:[function(require,module,exports){
 /* @flow */
 
 "use strict";
@@ -1061,7 +1105,7 @@ exports["default"] = function (dest /*:: ?: Object*/, src /*:: ?: Object*/) /*: 
 };
 
 module.exports = exports["default"];
-},{"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/interop-require-default":141,"lodash/object/merge":433}],14:[function(require,module,exports){
+},{"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/interop-require-default":142,"lodash/object/merge":434}],15:[function(require,module,exports){
 /* @noflow */
 
 "use strict";
@@ -1093,7 +1137,7 @@ exports["default"] = function (ast /*: Object*/, comments /*:: ?: Array<Object>*
 };
 
 module.exports = exports["default"];
-},{"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],15:[function(require,module,exports){
+},{"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],16:[function(require,module,exports){
 (function (process){
 "use strict";
 
@@ -1130,7 +1174,7 @@ exports["default"] = function (loc /*: string*/) /*: ?string*/ {
 
 module.exports = exports["default"];
 }).call(this,require('_process'))
-},{"_process":448,"babel-runtime/helpers/interop-require-default":141,"module":228}],16:[function(require,module,exports){
+},{"_process":449,"babel-runtime/helpers/interop-require-default":142,"module":229}],17:[function(require,module,exports){
 "use strict";
 
 var _inherits = require("babel-runtime/helpers/inherits")["default"];
@@ -1172,7 +1216,7 @@ var Store = (function (_Map) {
 
 exports["default"] = Store;
 module.exports = exports["default"];
-},{"babel-runtime/core-js/map":125,"babel-runtime/helpers/class-call-check":137,"babel-runtime/helpers/inherits":139}],17:[function(require,module,exports){
+},{"babel-runtime/core-js/map":126,"babel-runtime/helpers/class-call-check":138,"babel-runtime/helpers/inherits":140}],18:[function(require,module,exports){
 "use strict";
 
 var _interopRequireWildcard = require("babel-runtime/helpers/interop-require-wildcard")["default"];
@@ -1279,7 +1323,7 @@ exports["default"] = function (whitelist /*:: ?: Array<string>*/) {
 };
 
 module.exports = exports["default"];
-},{"babel-generator":43,"babel-helpers":65,"babel-messages":66,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-template":144,"babel-types":201,"lodash/collection/each":341}],18:[function(require,module,exports){
+},{"babel-generator":44,"babel-helpers":66,"babel-messages":67,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-template":145,"babel-types":202,"lodash/collection/each":342}],19:[function(require,module,exports){
 (function (process){
 /* @noflow */
 /* global BabelParserOptions */
@@ -1963,7 +2007,7 @@ var File = (function (_Store) {
 exports["default"] = File;
 exports.File = File;
 }).call(this,require('_process'))
-},{"../../store":16,"../../util":30,"../internal-plugins/block-hoist":25,"../internal-plugins/shadow-functions":26,"../plugin-pass":28,"./logger":19,"./metadata":20,"./options/option-manager":23,"_process":448,"babel-code-frame":10,"babel-generator":43,"babel-helpers":65,"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/class-call-check":137,"babel-runtime/helpers/inherits":139,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-traverse":147,"babel-types":201,"babylon":205,"convert-source-map":235,"lodash/object/defaults":428,"path":443,"shebang-regex":472,"source-map":484}],19:[function(require,module,exports){
+},{"../../store":17,"../../util":31,"../internal-plugins/block-hoist":26,"../internal-plugins/shadow-functions":27,"../plugin-pass":29,"./logger":20,"./metadata":21,"./options/option-manager":24,"_process":449,"babel-code-frame":11,"babel-generator":44,"babel-helpers":66,"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/class-call-check":138,"babel-runtime/helpers/inherits":140,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-traverse":148,"babel-types":202,"babylon":206,"convert-source-map":236,"lodash/object/defaults":429,"path":444,"shebang-regex":473,"source-map":485}],20:[function(require,module,exports){
 "use strict";
 
 var _classCallCheck = require("babel-runtime/helpers/class-call-check")["default"];
@@ -2038,7 +2082,7 @@ var Logger = (function () {
 
 exports["default"] = Logger;
 module.exports = exports["default"];
-},{"babel-runtime/helpers/class-call-check":137,"babel-runtime/helpers/interop-require-default":141,"debug/node":317}],20:[function(require,module,exports){
+},{"babel-runtime/helpers/class-call-check":138,"babel-runtime/helpers/interop-require-default":142,"debug/node":318}],21:[function(require,module,exports){
 "use strict";
 
 var _getIterator = require("babel-runtime/core-js/get-iterator")["default"];
@@ -2221,7 +2265,7 @@ function ExportDeclaration(path, file) {
 function Scope(path) {
   path.skip();
 }
-},{"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],21:[function(require,module,exports){
+},{"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],22:[function(require,module,exports){
 "use strict";
 
 module.exports = {
@@ -2411,7 +2455,7 @@ module.exports = {
     type: "string"
   }
 };
-},{}],22:[function(require,module,exports){
+},{}],23:[function(require,module,exports){
 /* @flow */
 
 "use strict";
@@ -2452,7 +2496,7 @@ function normaliseOptions() /*: Object*/ {
 
   return options;
 }
-},{"./config":21,"./parsers":24,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142}],23:[function(require,module,exports){
+},{"./config":22,"./parsers":25,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143}],24:[function(require,module,exports){
 (function (process){
 "use strict";
 
@@ -2885,7 +2929,7 @@ exports["default"] = OptionManager;
 OptionManager.memoisedPlugins = [];
 module.exports = exports["default"];
 }).call(this,require('_process'))
-},{"../../../api/node":12,"../../../helpers/merge":13,"../../../helpers/resolve":15,"../../plugin":29,"./config":21,"./index":22,"_process":448,"babel-messages":66,"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/class-call-check":137,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"fs":228,"json5":333,"lodash/lang/clone":413,"lodash/lang/cloneDeep":414,"path":443,"path-exists":444,"path-is-absolute":445}],24:[function(require,module,exports){
+},{"../../../api/node":13,"../../../helpers/merge":14,"../../../helpers/resolve":16,"../../plugin":30,"./config":22,"./index":23,"_process":449,"babel-messages":67,"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/class-call-check":138,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"fs":229,"json5":334,"lodash/lang/clone":414,"lodash/lang/cloneDeep":415,"path":444,"path-exists":445,"path-is-absolute":446}],25:[function(require,module,exports){
 /* @flow */
 
 "use strict";
@@ -2922,7 +2966,7 @@ function booleanString(val /*: any*/) /*: boolean | any*/ {
 function list(val /*: any*/) /*: Array<string>*/ {
   return util.list(val);
 }
-},{"../../../util":30,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"slash":473}],25:[function(require,module,exports){
+},{"../../../util":31,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"slash":474}],26:[function(require,module,exports){
 /* @flow */
 
 "use strict";
@@ -2979,7 +3023,7 @@ exports["default"] = new _plugin2["default"]({
   }
 });
 module.exports = exports["default"];
-},{"../plugin":29,"babel-runtime/helpers/interop-require-default":141,"lodash/collection/sortBy":345}],26:[function(require,module,exports){
+},{"../plugin":30,"babel-runtime/helpers/interop-require-default":142,"lodash/collection/sortBy":346}],27:[function(require,module,exports){
 "use strict";
 
 var _interopRequireDefault = require("babel-runtime/helpers/interop-require-default")["default"];
@@ -3064,7 +3108,7 @@ function remap(path, key, create) {
   return path.replaceWith(id);
 }
 module.exports = exports["default"];
-},{"../plugin":29,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],27:[function(require,module,exports){
+},{"../plugin":30,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],28:[function(require,module,exports){
 /* @noflow */
 
 "use strict";
@@ -3130,7 +3174,7 @@ var Pipeline = (function () {
 
 exports["default"] = Pipeline;
 module.exports = exports["default"];
-},{"../helpers/normalize-ast":14,"./file":18,"babel-runtime/helpers/class-call-check":137,"babel-runtime/helpers/interop-require-default":141}],28:[function(require,module,exports){
+},{"../helpers/normalize-ast":15,"./file":19,"babel-runtime/helpers/class-call-check":138,"babel-runtime/helpers/interop-require-default":142}],29:[function(require,module,exports){
 "use strict";
 
 var _inherits = require("babel-runtime/helpers/inherits")["default"];
@@ -3212,7 +3256,7 @@ var PluginPass = (function (_Store) {
 
 exports["default"] = PluginPass;
 module.exports = exports["default"];
-},{"../store":16,"./file":18,"babel-runtime/helpers/class-call-check":137,"babel-runtime/helpers/inherits":139,"babel-runtime/helpers/interop-require-default":141,"babel-traverse":147}],29:[function(require,module,exports){
+},{"../store":17,"./file":19,"babel-runtime/helpers/class-call-check":138,"babel-runtime/helpers/inherits":140,"babel-runtime/helpers/interop-require-default":142,"babel-traverse":148}],30:[function(require,module,exports){
 /* @noflow */
 
 "use strict";
@@ -3372,7 +3416,7 @@ var Plugin = (function (_Store) {
 
 exports["default"] = Plugin;
 module.exports = exports["default"];
-},{"../store":16,"./file/options/option-manager":23,"babel-messages":66,"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/class-call-check":137,"babel-runtime/helpers/inherits":139,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-traverse":147,"lodash/lang/clone":413,"lodash/object/assign":427}],30:[function(require,module,exports){
+},{"../store":17,"./file/options/option-manager":24,"babel-messages":67,"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/class-call-check":138,"babel-runtime/helpers/inherits":140,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-traverse":148,"lodash/lang/clone":414,"lodash/object/assign":428}],31:[function(require,module,exports){
 /* @noflow */
 
 "use strict";
@@ -3588,7 +3632,7 @@ function _shouldIgnore(pattern /*: Function | RegExp*/, filename /*: string*/) {
     return pattern.test(filename);
   }
 }
-},{"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/interop-require-default":141,"lodash/collection/contains":340,"lodash/lang/isBoolean":417,"lodash/lang/isRegExp":423,"lodash/lang/isString":424,"lodash/string/escapeRegExp":436,"lodash/string/startsWith":437,"minimatch":440,"path":443,"slash":473,"util":492}],31:[function(require,module,exports){
+},{"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/interop-require-default":142,"lodash/collection/contains":341,"lodash/lang/isBoolean":418,"lodash/lang/isRegExp":424,"lodash/lang/isString":425,"lodash/string/escapeRegExp":437,"lodash/string/startsWith":438,"minimatch":441,"path":444,"slash":474,"util":493}],32:[function(require,module,exports){
 module.exports={
   "_args": [
     [
@@ -3683,7 +3727,7 @@ module.exports={
   "version": "6.3.26"
 }
 
-},{}],32:[function(require,module,exports){
+},{}],33:[function(require,module,exports){
 "use strict";
 
 var _classCallCheck = require("babel-runtime/helpers/class-call-check")["default"];
@@ -4037,7 +4081,7 @@ var Buffer = (function () {
 
 exports["default"] = Buffer;
 module.exports = exports["default"];
-},{"babel-runtime/helpers/class-call-check":137,"babel-runtime/helpers/interop-require-default":141,"repeating":469,"trim-right":489}],33:[function(require,module,exports){
+},{"babel-runtime/helpers/class-call-check":138,"babel-runtime/helpers/interop-require-default":142,"repeating":470,"trim-right":490}],34:[function(require,module,exports){
 /* @flow */
 
 "use strict";
@@ -4090,7 +4134,7 @@ function Directive(node /*: Object*/) {
 function DirectiveLiteral(node /*: Object*/) {
   this.push(this._stringLiteral(node.value));
 }
-},{}],34:[function(require,module,exports){
+},{}],35:[function(require,module,exports){
 /* @flow */
 
 "use strict";
@@ -4173,7 +4217,7 @@ function ClassMethod(node /*: Object*/) {
 
   this._method(node);
 }
-},{}],35:[function(require,module,exports){
+},{}],36:[function(require,module,exports){
 /* @flow */
 
 "use strict";
@@ -4453,7 +4497,7 @@ function getLeftMost(binaryExpr) {
   }
   return getLeftMost(binaryExpr.left);
 }
-},{"../node":44,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201,"is-integer":331,"lodash/lang/isNumber":420}],36:[function(require,module,exports){
+},{"../node":45,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202,"is-integer":332,"lodash/lang/isNumber":421}],37:[function(require,module,exports){
 /* @flow */
 
 "use strict";
@@ -4785,7 +4829,7 @@ function TypeCastExpression(node /*: Object*/) {
 function VoidTypeAnnotation() {
   this.push("void");
 }
-},{"./types":42,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],37:[function(require,module,exports){
+},{"./types":43,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],38:[function(require,module,exports){
 "use strict";
 
 var _getIterator = require("babel-runtime/core-js/get-iterator")["default"];
@@ -4887,7 +4931,7 @@ function JSXClosingElement(node /*: Object*/) {
 }
 
 function JSXEmptyExpression() {}
-},{"babel-runtime/core-js/get-iterator":124}],38:[function(require,module,exports){
+},{"babel-runtime/core-js/get-iterator":125}],39:[function(require,module,exports){
 /* @flow */
 
 "use strict";
@@ -4995,7 +5039,7 @@ function ArrowFunctionExpression(node /*: Object*/) {
     this.push(")");
   }
 }
-},{"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],39:[function(require,module,exports){
+},{"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],40:[function(require,module,exports){
 /* @flow */
 
 "use strict";
@@ -5155,7 +5199,7 @@ function ImportNamespaceSpecifier(node /*: Object*/) {
   this.push("* as ");
   this.print(node.local, node);
 }
-},{"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],40:[function(require,module,exports){
+},{"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],41:[function(require,module,exports){
 "use strict";
 
 var _getIterator = require("babel-runtime/core-js/get-iterator")["default"];
@@ -5462,7 +5506,7 @@ function VariableDeclarator(node /*: Object*/) {
     this.print(node.init, node);
   }
 }
-},{"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201,"repeating":469}],41:[function(require,module,exports){
+},{"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202,"repeating":470}],42:[function(require,module,exports){
 /* @flow */
 
 "use strict";
@@ -5498,7 +5542,7 @@ function TemplateLiteral(node /*: Object*/) {
 
   this._push("`");
 }
-},{}],42:[function(require,module,exports){
+},{}],43:[function(require,module,exports){
 /* @flow */
 
 /* eslint quotes: 0 */
@@ -5659,7 +5703,7 @@ function _stringLiteral(val /*: string*/, parent /*: Object*/) /*: string*/ {
 
   return val;
 }
-},{"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],43:[function(require,module,exports){
+},{"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],44:[function(require,module,exports){
 "use strict";
 
 var _inherits = require("babel-runtime/helpers/inherits")["default"];
@@ -5836,7 +5880,7 @@ exports["default"] = function (ast /*: Object*/, opts /*: Object*/, code /*: str
   var gen = new CodeGenerator(ast, opts, code);
   return gen.generate();
 };
-},{"./position":47,"./printer":48,"./source-map":49,"./whitespace":50,"babel-messages":66,"babel-runtime/helpers/class-call-check":137,"babel-runtime/helpers/inherits":139,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"detect-indent":318}],44:[function(require,module,exports){
+},{"./position":48,"./printer":49,"./source-map":50,"./whitespace":51,"babel-messages":67,"babel-runtime/helpers/class-call-check":138,"babel-runtime/helpers/inherits":140,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"detect-indent":319}],45:[function(require,module,exports){
 /* @noflow */
 
 "use strict";
@@ -5970,7 +6014,7 @@ _lodashCollectionEach2["default"](Node, function (fn, key) {
   };
 });
 module.exports = exports["default"];
-},{"./parentheses":45,"./whitespace":46,"babel-runtime/core-js/object/keys":133,"babel-runtime/helpers/class-call-check":137,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201,"lodash/collection/each":341}],45:[function(require,module,exports){
+},{"./parentheses":46,"./whitespace":47,"babel-runtime/core-js/object/keys":134,"babel-runtime/helpers/class-call-check":138,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202,"lodash/collection/each":342}],46:[function(require,module,exports){
 /* @flow */
 
 "use strict";
@@ -6244,7 +6288,7 @@ function isFirstInStatement(printStack /*: Array<Object>*/) /*: boolean*/ {
 
   return false;
 }
-},{"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],46:[function(require,module,exports){
+},{"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],47:[function(require,module,exports){
 "use strict";
 
 var _interopRequireDefault = require("babel-runtime/helpers/interop-require-default")["default"];
@@ -6487,7 +6531,7 @@ _lodashCollectionEach2["default"]({
     };
   });
 });
-},{"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201,"lodash/collection/each":341,"lodash/collection/map":344,"lodash/lang/isBoolean":417}],47:[function(require,module,exports){
+},{"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202,"lodash/collection/each":342,"lodash/collection/map":345,"lodash/lang/isBoolean":418}],48:[function(require,module,exports){
 /* @flow */
 
 /**
@@ -6542,7 +6586,7 @@ var Position = (function () {
 
 exports["default"] = Position;
 module.exports = exports["default"];
-},{"babel-runtime/helpers/class-call-check":137}],48:[function(require,module,exports){
+},{"babel-runtime/helpers/class-call-check":138}],49:[function(require,module,exports){
 "use strict";
 
 var _inherits = require("babel-runtime/helpers/inherits")["default"];
@@ -6934,7 +6978,7 @@ for (var _i2 = 0; _i2 < _arr.length; _i2++) {
   _Object$assign(Printer.prototype, generator);
 }
 module.exports = exports["default"];
-},{"./buffer":32,"./generators/base":33,"./generators/classes":34,"./generators/expressions":35,"./generators/flow":36,"./generators/jsx":37,"./generators/methods":38,"./generators/modules":39,"./generators/statements":40,"./generators/template-literals":41,"./generators/types":42,"./node":44,"babel-runtime/core-js/get-iterator":124,"babel-runtime/core-js/object/assign":127,"babel-runtime/helpers/class-call-check":137,"babel-runtime/helpers/inherits":139,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201,"repeating":469}],49:[function(require,module,exports){
+},{"./buffer":33,"./generators/base":34,"./generators/classes":35,"./generators/expressions":36,"./generators/flow":37,"./generators/jsx":38,"./generators/methods":39,"./generators/modules":40,"./generators/statements":41,"./generators/template-literals":42,"./generators/types":43,"./node":45,"babel-runtime/core-js/get-iterator":125,"babel-runtime/core-js/object/assign":128,"babel-runtime/helpers/class-call-check":138,"babel-runtime/helpers/inherits":140,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202,"repeating":470}],50:[function(require,module,exports){
 "use strict";
 
 var _classCallCheck = require("babel-runtime/helpers/class-call-check")["default"];
@@ -7038,7 +7082,7 @@ function comparePosition(a, b) {
   return a.line === b.line && a.column === b.column;
 }
 module.exports = exports["default"];
-},{"babel-runtime/helpers/class-call-check":137,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201,"source-map":484}],50:[function(require,module,exports){
+},{"babel-runtime/helpers/class-call-check":138,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202,"source-map":485}],51:[function(require,module,exports){
 /**
  * Returns `i`th number from `base`, continuing from 0 when `max` is reached.
  * Useful for shifting `for` loop by a fixed number but going over all items.
@@ -7172,7 +7216,7 @@ var Whitespace = (function () {
 
 exports["default"] = Whitespace;
 module.exports = exports["default"];
-},{"babel-runtime/helpers/class-call-check":137}],51:[function(require,module,exports){
+},{"babel-runtime/helpers/class-call-check":138}],52:[function(require,module,exports){
 "use strict";
 
 var _getIterator = require("babel-runtime/core-js/get-iterator")["default"];
@@ -7229,7 +7273,7 @@ function bindifyDecorators(decorators /*: Array<NodePath>*/) /*: Array<NodePath>
 }
 
 module.exports = exports["default"];
-},{"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],52:[function(require,module,exports){
+},{"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],53:[function(require,module,exports){
 /* @flow */
 
 "use strict";
@@ -7301,7 +7345,7 @@ exports["default"] = function (opts /*: {
 };
 
 module.exports = exports["default"];
-},{"babel-helper-explode-assignable-expression":55,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],53:[function(require,module,exports){
+},{"babel-helper-explode-assignable-expression":56,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],54:[function(require,module,exports){
 "use strict";
 
 var _interopRequireDefault = require("babel-runtime/helpers/interop-require-default")["default"];
@@ -7380,7 +7424,7 @@ exports["default"] = function (path /*: NodePath*/) {
 };
 
 module.exports = exports["default"];
-},{"babel-helper-hoist-variables":59,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],54:[function(require,module,exports){
+},{"babel-helper-hoist-variables":60,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],55:[function(require,module,exports){
 "use strict";
 
 var _interopRequireDefault = require("babel-runtime/helpers/interop-require-default")["default"];
@@ -7546,7 +7590,7 @@ function toDefineObject(mutatorMap /*: Object*/) /*: Object*/ {
 
   return toClassObject(mutatorMap);
 }
-},{"babel-helper-function-name":57,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201,"lodash/collection/each":341,"lodash/object/has":430}],55:[function(require,module,exports){
+},{"babel-helper-function-name":58,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202,"lodash/collection/each":342,"lodash/object/has":431}],56:[function(require,module,exports){
 "use strict";
 
 var _interopRequireWildcard = require("babel-runtime/helpers/interop-require-wildcard")["default"];
@@ -7630,7 +7674,7 @@ exports["default"] = function (node /*: Object*/, nodes /*: Array<Object>*/, fil
 };
 
 module.exports = exports["default"];
-},{"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],56:[function(require,module,exports){
+},{"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],57:[function(require,module,exports){
 "use strict";
 
 var _getIterator = require("babel-runtime/core-js/get-iterator")["default"];
@@ -7725,7 +7769,7 @@ exports["default"] = function (classPath) {
 };
 
 module.exports = exports["default"];
-},{"babel-helper-bindify-decorators":51,"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],57:[function(require,module,exports){
+},{"babel-helper-bindify-decorators":52,"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],58:[function(require,module,exports){
 "use strict";
 
 var _interopRequireDefault = require("babel-runtime/helpers/interop-require-default")["default"];
@@ -7893,7 +7937,7 @@ exports["default"] = function (_ref) {
 };
 
 module.exports = exports["default"];
-},{"babel-helper-get-function-arity":58,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-template":144,"babel-types":201}],58:[function(require,module,exports){
+},{"babel-helper-get-function-arity":59,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-template":145,"babel-types":202}],59:[function(require,module,exports){
 "use strict";
 
 var _interopRequireWildcard = require("babel-runtime/helpers/interop-require-wildcard")["default"];
@@ -7916,7 +7960,7 @@ exports["default"] = function (node) /*: number*/ {
 };
 
 module.exports = exports["default"];
-},{"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],59:[function(require,module,exports){
+},{"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],60:[function(require,module,exports){
 "use strict";
 
 var _getIterator = require("babel-runtime/core-js/get-iterator")["default"];
@@ -7987,7 +8031,7 @@ exports["default"] = function (path, emit /*: Function*/) {
 };
 
 module.exports = exports["default"];
-},{"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],60:[function(require,module,exports){
+},{"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],61:[function(require,module,exports){
 "use strict";
 
 var _interopRequireWildcard = require("babel-runtime/helpers/interop-require-wildcard")["default"];
@@ -8008,7 +8052,7 @@ exports["default"] = function (callee, thisNode, args) {
 };
 
 module.exports = exports["default"];
-},{"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],61:[function(require,module,exports){
+},{"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],62:[function(require,module,exports){
 /* @flow */
 
 "use strict";
@@ -8039,7 +8083,7 @@ function pullFlag(node /*: Object*/, flag /*: string*/) {
   _lodashArrayPull2["default"](flags, flag);
   node.flags = flags.join("");
 }
-},{"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201,"lodash/array/pull":338}],62:[function(require,module,exports){
+},{"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202,"lodash/array/pull":339}],63:[function(require,module,exports){
 /* @flow */
 
 "use strict";
@@ -8168,7 +8212,7 @@ exports["default"] = function (path /*: NodePath*/, callId /*: Object*/) {
 };
 
 module.exports = exports["default"];
-},{"babel-helper-function-name":57,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-template":144,"babel-types":201}],63:[function(require,module,exports){
+},{"babel-helper-function-name":58,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-template":145,"babel-types":202}],64:[function(require,module,exports){
 "use strict";
 
 var _classCallCheck = require("babel-runtime/helpers/class-call-check")["default"];
@@ -8424,7 +8468,7 @@ var ReplaceSupers = (function () {
 
 exports["default"] = ReplaceSupers;
 module.exports = exports["default"];
-},{"babel-helper-optimise-call-expression":60,"babel-messages":66,"babel-runtime/core-js/symbol":135,"babel-runtime/helpers/class-call-check":137,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],64:[function(require,module,exports){
+},{"babel-helper-optimise-call-expression":61,"babel-messages":67,"babel-runtime/core-js/symbol":136,"babel-runtime/helpers/class-call-check":138,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],65:[function(require,module,exports){
 "use strict";
 
 var _interopRequireDefault = require("babel-runtime/helpers/interop-require-default")["default"];
@@ -8494,7 +8538,7 @@ helpers.toArray = _babelTemplate2["default"]("\n  (function (arr) {\n    return 
 
 helpers.toConsumableArray = _babelTemplate2["default"]("\n  (function (arr) {\n    if (Array.isArray(arr)) {\n      for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) arr2[i] = arr[i];\n      return arr2;\n    } else {\n      return Array.from(arr);\n    }\n  });\n");
 module.exports = exports["default"];
-},{"babel-runtime/helpers/interop-require-default":141,"babel-template":144}],65:[function(require,module,exports){
+},{"babel-runtime/helpers/interop-require-default":142,"babel-template":145}],66:[function(require,module,exports){
 "use strict";
 
 var _Object$keys = require("babel-runtime/core-js/object/keys")["default"];
@@ -8523,7 +8567,7 @@ var list = _Object$keys(_helpers2["default"]).map(function (name) {
 
 exports.list = list;
 exports["default"] = get;
-},{"./helpers":64,"babel-runtime/core-js/object/keys":133,"babel-runtime/helpers/interop-require-default":141}],66:[function(require,module,exports){
+},{"./helpers":65,"babel-runtime/core-js/object/keys":134,"babel-runtime/helpers/interop-require-default":142}],67:[function(require,module,exports){
 /* @flow */
 
 "use strict";
@@ -8618,7 +8662,7 @@ function parseArgs(args /*: Array<any>*/) /*: Array<string>*/ {
     }
   });
 }
-},{"babel-runtime/helpers/interop-require-wildcard":142,"util":492}],67:[function(require,module,exports){
+},{"babel-runtime/helpers/interop-require-wildcard":143,"util":493}],68:[function(require,module,exports){
 "use strict";
 
 var _getIterator = require("babel-runtime/core-js/get-iterator")["default"];
@@ -8660,7 +8704,7 @@ exports["default"] = function (_ref2) {
 };
 
 module.exports = exports["default"];
-},{"babel-runtime/core-js/get-iterator":124}],68:[function(require,module,exports){
+},{"babel-runtime/core-js/get-iterator":125}],69:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -8674,7 +8718,7 @@ exports["default"] = function () {
 };
 
 module.exports = exports["default"];
-},{}],69:[function(require,module,exports){
+},{}],70:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -8688,7 +8732,7 @@ exports["default"] = function () {
 };
 
 module.exports = exports["default"];
-},{}],70:[function(require,module,exports){
+},{}],71:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -8702,7 +8746,7 @@ exports["default"] = function () {
 };
 
 module.exports = exports["default"];
-},{}],71:[function(require,module,exports){
+},{}],72:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -8716,7 +8760,7 @@ exports["default"] = function () {
 };
 
 module.exports = exports["default"];
-},{}],72:[function(require,module,exports){
+},{}],73:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -8730,7 +8774,7 @@ exports["default"] = function () {
 };
 
 module.exports = exports["default"];
-},{}],73:[function(require,module,exports){
+},{}],74:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -8744,7 +8788,7 @@ exports["default"] = function () {
 };
 
 module.exports = exports["default"];
-},{}],74:[function(require,module,exports){
+},{}],75:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -8758,7 +8802,7 @@ exports["default"] = function () {
 };
 
 module.exports = exports["default"];
-},{}],75:[function(require,module,exports){
+},{}],76:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -8772,7 +8816,7 @@ exports["default"] = function () {
 };
 
 module.exports = exports["default"];
-},{}],76:[function(require,module,exports){
+},{}],77:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -8786,7 +8830,7 @@ exports["default"] = function () {
 };
 
 module.exports = exports["default"];
-},{}],77:[function(require,module,exports){
+},{}],78:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -8800,7 +8844,7 @@ exports["default"] = function () {
 };
 
 module.exports = exports["default"];
-},{}],78:[function(require,module,exports){
+},{}],79:[function(require,module,exports){
 "use strict";
 
 var _interopRequireDefault = require("babel-runtime/helpers/interop-require-default")["default"];
@@ -8826,7 +8870,7 @@ exports["default"] = function () {
 };
 
 module.exports = exports["default"];
-},{"babel-helper-remap-async-to-generator":62,"babel-plugin-syntax-async-functions":68,"babel-runtime/helpers/interop-require-default":141}],79:[function(require,module,exports){
+},{"babel-helper-remap-async-to-generator":63,"babel-plugin-syntax-async-functions":69,"babel-runtime/helpers/interop-require-default":142}],80:[function(require,module,exports){
 "use strict";
 
 var _Symbol = require("babel-runtime/core-js/symbol")["default"];
@@ -8916,7 +8960,7 @@ exports["default"] = function (_ref2) {
 };
 
 module.exports = exports["default"];
-},{"babel-plugin-syntax-class-constructor-call":69,"babel-runtime/core-js/get-iterator":124,"babel-runtime/core-js/symbol":135,"babel-runtime/helpers/interop-require-default":141,"babel-template":144}],80:[function(require,module,exports){
+},{"babel-plugin-syntax-class-constructor-call":70,"babel-runtime/core-js/get-iterator":125,"babel-runtime/core-js/symbol":136,"babel-runtime/helpers/interop-require-default":142,"babel-template":145}],81:[function(require,module,exports){
 // todo: define instead of assign
 
 "use strict";
@@ -9079,7 +9123,7 @@ exports["default"] = function (_ref2) {
 };
 
 module.exports = exports["default"];
-},{"babel-plugin-syntax-class-properties":70,"babel-runtime/core-js/get-iterator":124}],81:[function(require,module,exports){
+},{"babel-plugin-syntax-class-properties":71,"babel-runtime/core-js/get-iterator":125}],82:[function(require,module,exports){
 "use strict";
 
 var _getIterator = require("babel-runtime/core-js/get-iterator")["default"];
@@ -9272,7 +9316,7 @@ exports["default"] = function (_ref5) {
 };
 
 module.exports = exports["default"];
-},{"babel-helper-explode-class":56,"babel-plugin-syntax-decorators":71,"babel-runtime/core-js/get-iterator":124,"babel-runtime/core-js/object/create":128,"babel-runtime/helpers/interop-require-default":141,"babel-template":144}],82:[function(require,module,exports){
+},{"babel-helper-explode-class":57,"babel-plugin-syntax-decorators":72,"babel-runtime/core-js/get-iterator":125,"babel-runtime/core-js/object/create":129,"babel-runtime/helpers/interop-require-default":142,"babel-template":145}],83:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -9295,7 +9339,7 @@ exports["default"] = function () {
 };
 
 module.exports = exports["default"];
-},{"babel-plugin-syntax-do-expressions":72}],83:[function(require,module,exports){
+},{"babel-plugin-syntax-do-expressions":73}],84:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -9331,7 +9375,7 @@ exports["default"] = function (_ref) {
 };
 
 module.exports = exports["default"];
-},{}],84:[function(require,module,exports){
+},{}],85:[function(require,module,exports){
 "use strict";
 
 var _getIterator = require("babel-runtime/core-js/get-iterator")["default"];
@@ -9394,7 +9438,7 @@ exports["default"] = function (_ref2) {
 };
 
 module.exports = exports["default"];
-},{"babel-runtime/core-js/get-iterator":124}],85:[function(require,module,exports){
+},{"babel-runtime/core-js/get-iterator":125}],86:[function(require,module,exports){
 "use strict";
 
 var _classCallCheck = require("babel-runtime/helpers/class-call-check")["default"];
@@ -10077,7 +10121,7 @@ var BlockScoping = (function () {
 })();
 
 module.exports = exports["default"];
-},{"./tdz":86,"babel-runtime/core-js/object/create":128,"babel-runtime/core-js/symbol":135,"babel-runtime/helpers/class-call-check":137,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-template":144,"babel-traverse":147,"babel-types":201,"lodash/object/extend":429,"lodash/object/values":435}],86:[function(require,module,exports){
+},{"./tdz":87,"babel-runtime/core-js/object/create":129,"babel-runtime/core-js/symbol":136,"babel-runtime/helpers/class-call-check":138,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-template":145,"babel-traverse":148,"babel-types":202,"lodash/object/extend":430,"lodash/object/values":436}],87:[function(require,module,exports){
 "use strict";
 
 var _interopRequireWildcard = require("babel-runtime/helpers/interop-require-wildcard")["default"];
@@ -10175,7 +10219,7 @@ var visitor = {
   }
 };
 exports.visitor = visitor;
-},{"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],87:[function(require,module,exports){
+},{"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],88:[function(require,module,exports){
 "use strict";
 
 var _Symbol = require("babel-runtime/core-js/symbol")["default"];
@@ -10245,7 +10289,7 @@ exports["default"] = function (_ref) {
 };
 
 module.exports = exports["default"];
-},{"./loose":88,"./vanilla":89,"babel-helper-function-name":57,"babel-runtime/core-js/symbol":135,"babel-runtime/helpers/interop-require-default":141}],88:[function(require,module,exports){
+},{"./loose":89,"./vanilla":90,"babel-helper-function-name":58,"babel-runtime/core-js/symbol":136,"babel-runtime/helpers/interop-require-default":142}],89:[function(require,module,exports){
 "use strict";
 
 var _inherits = require("babel-runtime/helpers/inherits")["default"];
@@ -10310,7 +10354,7 @@ var LooseClassTransformer = (function (_VanillaTransformer) {
 
 exports["default"] = LooseClassTransformer;
 module.exports = exports["default"];
-},{"./vanilla":89,"babel-helper-function-name":57,"babel-runtime/helpers/class-call-check":137,"babel-runtime/helpers/inherits":139,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],89:[function(require,module,exports){
+},{"./vanilla":90,"babel-helper-function-name":58,"babel-runtime/helpers/class-call-check":138,"babel-runtime/helpers/inherits":140,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],90:[function(require,module,exports){
 "use strict";
 
 var _classCallCheck = require("babel-runtime/helpers/class-call-check")["default"];
@@ -10911,7 +10955,7 @@ var ClassTransformer = (function () {
 
 exports["default"] = ClassTransformer;
 module.exports = exports["default"];
-},{"babel-helper-define-map":54,"babel-helper-optimise-call-expression":60,"babel-helper-replace-supers":63,"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/class-call-check":137,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-template":144,"babel-traverse":147,"babel-types":201}],90:[function(require,module,exports){
+},{"babel-helper-define-map":55,"babel-helper-optimise-call-expression":61,"babel-helper-replace-supers":64,"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/class-call-check":138,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-template":145,"babel-traverse":148,"babel-types":202}],91:[function(require,module,exports){
 "use strict";
 
 var _getIterator = require("babel-runtime/core-js/get-iterator")["default"];
@@ -11129,7 +11173,7 @@ exports["default"] = function (_ref5) {
 };
 
 module.exports = exports["default"];
-},{"babel-runtime/core-js/get-iterator":124}],91:[function(require,module,exports){
+},{"babel-runtime/core-js/get-iterator":125}],92:[function(require,module,exports){
 "use strict";
 
 var _classCallCheck = require("babel-runtime/helpers/class-call-check")["default"];
@@ -11675,7 +11719,7 @@ exports["default"] = function (_ref5) {
 };
 
 module.exports = exports["default"];
-},{"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/class-call-check":137}],92:[function(require,module,exports){
+},{"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/class-call-check":138}],93:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -11876,7 +11920,7 @@ exports["default"] = function (_ref) {
 };
 
 module.exports = exports["default"];
-},{}],93:[function(require,module,exports){
+},{}],94:[function(require,module,exports){
 "use strict";
 
 var _interopRequireDefault = require("babel-runtime/helpers/interop-require-default")["default"];
@@ -11911,7 +11955,7 @@ exports["default"] = function () {
 };
 
 module.exports = exports["default"];
-},{"babel-helper-function-name":57,"babel-runtime/helpers/interop-require-default":141}],94:[function(require,module,exports){
+},{"babel-helper-function-name":58,"babel-runtime/helpers/interop-require-default":142}],95:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -11941,7 +11985,7 @@ exports["default"] = function () {
 };
 
 module.exports = exports["default"];
-},{}],95:[function(require,module,exports){
+},{}],96:[function(require,module,exports){
 "use strict";
 
 var _Symbol = require("babel-runtime/core-js/symbol")["default"];
@@ -12424,7 +12468,7 @@ exports["default"] = function () {
 };
 
 module.exports = exports["default"];
-},{"babel-plugin-transform-strict-mode":118,"babel-runtime/core-js/get-iterator":124,"babel-runtime/core-js/object/create":128,"babel-runtime/core-js/object/keys":133,"babel-runtime/core-js/symbol":135,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-template":144,"babel-types":201,"path":443}],96:[function(require,module,exports){
+},{"babel-plugin-transform-strict-mode":119,"babel-runtime/core-js/get-iterator":125,"babel-runtime/core-js/object/create":129,"babel-runtime/core-js/object/keys":134,"babel-runtime/core-js/symbol":136,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-template":145,"babel-types":202,"path":444}],97:[function(require,module,exports){
 "use strict";
 
 var _Symbol = require("babel-runtime/core-js/symbol")["default"];
@@ -12505,7 +12549,7 @@ exports["default"] = function (_ref2) {
 };
 
 module.exports = exports["default"];
-},{"babel-helper-replace-supers":63,"babel-runtime/core-js/get-iterator":124,"babel-runtime/core-js/symbol":135,"babel-runtime/helpers/interop-require-default":141}],97:[function(require,module,exports){
+},{"babel-helper-replace-supers":64,"babel-runtime/core-js/get-iterator":125,"babel-runtime/core-js/symbol":136,"babel-runtime/helpers/interop-require-default":142}],98:[function(require,module,exports){
 "use strict";
 
 var _getIterator = require("babel-runtime/core-js/get-iterator")["default"];
@@ -12682,7 +12726,7 @@ var visitor = {
   }
 };
 exports.visitor = visitor;
-},{"babel-helper-call-delegate":53,"babel-helper-get-function-arity":58,"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-template":144,"babel-types":201}],98:[function(require,module,exports){
+},{"babel-helper-call-delegate":54,"babel-helper-get-function-arity":59,"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-template":145,"babel-types":202}],99:[function(require,module,exports){
 "use strict";
 
 var _interopRequireWildcard = require("babel-runtime/helpers/interop-require-wildcard")["default"];
@@ -12719,7 +12763,7 @@ var visitor = {
   }
 };
 exports.visitor = visitor;
-},{"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],99:[function(require,module,exports){
+},{"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],100:[function(require,module,exports){
 "use strict";
 
 var _getIterator = require("babel-runtime/core-js/get-iterator")["default"];
@@ -12774,7 +12818,7 @@ exports["default"] = function () {
 };
 
 module.exports = exports["default"];
-},{"./default":97,"./destructuring":98,"./rest":100,"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/interop-require-wildcard":142,"babel-traverse":147}],100:[function(require,module,exports){
+},{"./default":98,"./destructuring":99,"./rest":101,"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/interop-require-wildcard":143,"babel-traverse":148}],101:[function(require,module,exports){
 "use strict";
 
 var _getIterator = require("babel-runtime/core-js/get-iterator")["default"];
@@ -13055,7 +13099,7 @@ var visitor = {
   }
 };
 exports.visitor = visitor;
-},{"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-template":144,"babel-types":201}],101:[function(require,module,exports){
+},{"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-template":145,"babel-types":202}],102:[function(require,module,exports){
 "use strict";
 
 var _interopRequireWildcard = require("babel-runtime/helpers/interop-require-wildcard")["default"];
@@ -13089,7 +13133,7 @@ exports["default"] = function () {
 };
 
 module.exports = exports["default"];
-},{"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],102:[function(require,module,exports){
+},{"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],103:[function(require,module,exports){
 "use strict";
 
 var _getIterator = require("babel-runtime/core-js/get-iterator")["default"];
@@ -13240,7 +13284,7 @@ exports["default"] = function (_ref2) {
 };
 
 module.exports = exports["default"];
-},{"babel-runtime/core-js/get-iterator":124}],103:[function(require,module,exports){
+},{"babel-runtime/core-js/get-iterator":125}],104:[function(require,module,exports){
 "use strict";
 
 var _interopRequireWildcard = require("babel-runtime/helpers/interop-require-wildcard")["default"];
@@ -13270,7 +13314,7 @@ exports["default"] = function () {
 };
 
 module.exports = exports["default"];
-},{"babel-helper-regex":61,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],104:[function(require,module,exports){
+},{"babel-helper-regex":62,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],105:[function(require,module,exports){
 "use strict";
 
 var _getIterator = require("babel-runtime/core-js/get-iterator")["default"];
@@ -13403,7 +13447,7 @@ exports["default"] = function (_ref4) {
 };
 
 module.exports = exports["default"];
-},{"babel-runtime/core-js/get-iterator":124}],105:[function(require,module,exports){
+},{"babel-runtime/core-js/get-iterator":125}],106:[function(require,module,exports){
 "use strict";
 
 var _Symbol = require("babel-runtime/core-js/symbol")["default"];
@@ -13461,7 +13505,7 @@ exports["default"] = function (_ref) {
 };
 
 module.exports = exports["default"];
-},{"babel-runtime/core-js/symbol":135}],106:[function(require,module,exports){
+},{"babel-runtime/core-js/symbol":136}],107:[function(require,module,exports){
 "use strict";
 
 var _interopRequireDefault = require("babel-runtime/helpers/interop-require-default")["default"];
@@ -13493,7 +13537,7 @@ exports["default"] = function () {
 };
 
 module.exports = exports["default"];
-},{"babel-helper-regex":61,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"regexpu-core":466}],107:[function(require,module,exports){
+},{"babel-helper-regex":62,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"regexpu-core":467}],108:[function(require,module,exports){
 "use strict";
 
 var _interopRequireDefault = require("babel-runtime/helpers/interop-require-default")["default"];
@@ -13521,7 +13565,7 @@ exports["default"] = function (_ref) {
 };
 
 module.exports = exports["default"];
-},{"babel-helper-builder-binary-assignment-operator-visitor":52,"babel-plugin-syntax-exponentiation-operator":73,"babel-runtime/helpers/interop-require-default":141}],108:[function(require,module,exports){
+},{"babel-helper-builder-binary-assignment-operator-visitor":53,"babel-plugin-syntax-exponentiation-operator":74,"babel-runtime/helpers/interop-require-default":142}],109:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -13571,7 +13615,7 @@ exports["default"] = function (_ref) {
 };
 
 module.exports = exports["default"];
-},{"babel-plugin-syntax-export-extensions":74}],109:[function(require,module,exports){
+},{"babel-plugin-syntax-export-extensions":75}],110:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -13633,7 +13677,7 @@ exports["default"] = function (_ref) {
 };
 
 module.exports = exports["default"];
-},{"babel-plugin-syntax-function-bind":75}],110:[function(require,module,exports){
+},{"babel-plugin-syntax-function-bind":76}],111:[function(require,module,exports){
 "use strict";
 
 var _getIterator = require("babel-runtime/core-js/get-iterator")["default"];
@@ -13716,7 +13760,7 @@ exports["default"] = function (_ref3) {
 };
 
 module.exports = exports["default"];
-},{"babel-plugin-syntax-object-rest-spread":76,"babel-runtime/core-js/get-iterator":124}],111:[function(require,module,exports){
+},{"babel-plugin-syntax-object-rest-spread":77,"babel-runtime/core-js/get-iterator":125}],112:[function(require,module,exports){
 /**
  * Copyright (c) 2014, Facebook, Inc.
  * All rights reserved.
@@ -14713,7 +14757,7 @@ Ep.explodeExpression = function (path, ignoreResult) {
       throw new Error("unknown Expression of type " + JSON.stringify(expr.type));
   }
 };
-},{"./leap":114,"./meta":115,"./util":116,"assert":9,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],112:[function(require,module,exports){
+},{"./leap":115,"./meta":116,"./util":117,"assert":10,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],113:[function(require,module,exports){
 /**
  * Copyright (c) 2014, Facebook, Inc.
  * All rights reserved.
@@ -14855,7 +14899,7 @@ exports.hoist = function (funPath) {
 
   return t.variableDeclaration("var", declarations);
 };
-},{"babel-runtime/core-js/object/keys":133,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],113:[function(require,module,exports){
+},{"babel-runtime/core-js/object/keys":134,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],114:[function(require,module,exports){
 /**
  * Copyright (c) 2014, Facebook, Inc.
  * All rights reserved.
@@ -14875,7 +14919,7 @@ exports["default"] = function () {
 };
 
 module.exports = exports["default"];
-},{"./visit":117}],114:[function(require,module,exports){
+},{"./visit":118}],115:[function(require,module,exports){
 /**
  * Copyright (c) 2014, Facebook, Inc.
  * All rights reserved.
@@ -15061,7 +15105,7 @@ LMp.getBreakLoc = function (label) {
 LMp.getContinueLoc = function (label) {
   return this._findLeapLocation("continueLoc", label);
 };
-},{"./emit":111,"assert":9,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201,"util":492}],115:[function(require,module,exports){
+},{"./emit":112,"assert":10,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202,"util":493}],116:[function(require,module,exports){
 /**
  * Copyright (c) 2014, Facebook, Inc.
  * All rights reserved.
@@ -15175,7 +15219,7 @@ for (var type in leapTypes) {
 
 exports.hasSideEffects = makePredicate("hasSideEffects", sideEffectTypes);
 exports.containsLeap = makePredicate("containsLeap", leapTypes);
-},{"assert":9,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201,"private":447}],116:[function(require,module,exports){
+},{"assert":10,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202,"private":448}],117:[function(require,module,exports){
 /**
  * Copyright (c) 2014, Facebook, Inc.
  * All rights reserved.
@@ -15205,7 +15249,7 @@ function runtimeProperty(name) {
 function isReference(path) {
   return path.isReferenced() || path.parentPath.isAssignmentExpression({ left: path.node });
 }
-},{"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],117:[function(require,module,exports){
+},{"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],118:[function(require,module,exports){
 /**
  * Copyright (c) 2014, Facebook, Inc.
  * All rights reserved.
@@ -15461,7 +15505,7 @@ var awaitVisitor = {
     path.replaceWith(t.yieldExpression(t.callExpression(util.runtimeProperty("awrap"), [argument]), false));
   }
 };
-},{"./emit":111,"./hoist":112,"./util":116,"assert":9,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201,"private":447}],118:[function(require,module,exports){
+},{"./emit":112,"./hoist":113,"./util":117,"assert":10,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202,"private":448}],119:[function(require,module,exports){
 "use strict";
 
 var _getIterator = require("babel-runtime/core-js/get-iterator")["default"];
@@ -15506,7 +15550,7 @@ exports["default"] = function () {
 };
 
 module.exports = exports["default"];
-},{"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],119:[function(require,module,exports){
+},{"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],120:[function(require,module,exports){
 module.exports = {
   plugins: [
     require("babel-plugin-transform-es2015-template-literals"),
@@ -15532,7 +15576,7 @@ module.exports = {
   ]
 };
 
-},{"babel-plugin-check-es2015-constants":67,"babel-plugin-transform-es2015-arrow-functions":83,"babel-plugin-transform-es2015-block-scoped-functions":84,"babel-plugin-transform-es2015-block-scoping":85,"babel-plugin-transform-es2015-classes":87,"babel-plugin-transform-es2015-computed-properties":90,"babel-plugin-transform-es2015-destructuring":91,"babel-plugin-transform-es2015-for-of":92,"babel-plugin-transform-es2015-function-name":93,"babel-plugin-transform-es2015-literals":94,"babel-plugin-transform-es2015-modules-commonjs":95,"babel-plugin-transform-es2015-object-super":96,"babel-plugin-transform-es2015-parameters":99,"babel-plugin-transform-es2015-shorthand-properties":101,"babel-plugin-transform-es2015-spread":102,"babel-plugin-transform-es2015-sticky-regex":103,"babel-plugin-transform-es2015-template-literals":104,"babel-plugin-transform-es2015-typeof-symbol":105,"babel-plugin-transform-es2015-unicode-regex":106,"babel-plugin-transform-regenerator":113}],120:[function(require,module,exports){
+},{"babel-plugin-check-es2015-constants":68,"babel-plugin-transform-es2015-arrow-functions":84,"babel-plugin-transform-es2015-block-scoped-functions":85,"babel-plugin-transform-es2015-block-scoping":86,"babel-plugin-transform-es2015-classes":88,"babel-plugin-transform-es2015-computed-properties":91,"babel-plugin-transform-es2015-destructuring":92,"babel-plugin-transform-es2015-for-of":93,"babel-plugin-transform-es2015-function-name":94,"babel-plugin-transform-es2015-literals":95,"babel-plugin-transform-es2015-modules-commonjs":96,"babel-plugin-transform-es2015-object-super":97,"babel-plugin-transform-es2015-parameters":100,"babel-plugin-transform-es2015-shorthand-properties":102,"babel-plugin-transform-es2015-spread":103,"babel-plugin-transform-es2015-sticky-regex":104,"babel-plugin-transform-es2015-template-literals":105,"babel-plugin-transform-es2015-typeof-symbol":106,"babel-plugin-transform-es2015-unicode-regex":107,"babel-plugin-transform-regenerator":114}],121:[function(require,module,exports){
 module.exports = {
   presets: [
     require("babel-preset-stage-1")
@@ -15543,7 +15587,7 @@ module.exports = {
   ]
 };
 
-},{"babel-plugin-transform-do-expressions":82,"babel-plugin-transform-function-bind":109,"babel-preset-stage-1":121}],121:[function(require,module,exports){
+},{"babel-plugin-transform-do-expressions":83,"babel-plugin-transform-function-bind":110,"babel-preset-stage-1":122}],122:[function(require,module,exports){
 module.exports = {
   presets: [
     require("babel-preset-stage-2")
@@ -15556,7 +15600,7 @@ module.exports = {
   ]
 };
 
-},{"babel-plugin-transform-class-constructor-call":79,"babel-plugin-transform-class-properties":80,"babel-plugin-transform-decorators":81,"babel-plugin-transform-export-extensions":108,"babel-preset-stage-2":122}],122:[function(require,module,exports){
+},{"babel-plugin-transform-class-constructor-call":80,"babel-plugin-transform-class-properties":81,"babel-plugin-transform-decorators":82,"babel-plugin-transform-export-extensions":109,"babel-preset-stage-2":123}],123:[function(require,module,exports){
 module.exports = {
   presets: [
     require("babel-preset-stage-3")
@@ -15567,7 +15611,7 @@ module.exports = {
   ]
 };
 
-},{"babel-plugin-syntax-trailing-function-commas":77,"babel-plugin-transform-object-rest-spread":110,"babel-preset-stage-3":123}],123:[function(require,module,exports){
+},{"babel-plugin-syntax-trailing-function-commas":78,"babel-plugin-transform-object-rest-spread":111,"babel-preset-stage-3":124}],124:[function(require,module,exports){
 module.exports = {
   plugins: [
     require("babel-plugin-transform-async-to-generator"),
@@ -15575,33 +15619,33 @@ module.exports = {
   ]
 };
 
-},{"babel-plugin-transform-async-to-generator":78,"babel-plugin-transform-exponentiation-operator":107}],124:[function(require,module,exports){
+},{"babel-plugin-transform-async-to-generator":79,"babel-plugin-transform-exponentiation-operator":108}],125:[function(require,module,exports){
 module.exports = { "default": require("core-js/library/fn/get-iterator"), __esModule: true };
-},{"core-js/library/fn/get-iterator":236}],125:[function(require,module,exports){
+},{"core-js/library/fn/get-iterator":237}],126:[function(require,module,exports){
 module.exports = { "default": require("core-js/library/fn/map"), __esModule: true };
-},{"core-js/library/fn/map":237}],126:[function(require,module,exports){
+},{"core-js/library/fn/map":238}],127:[function(require,module,exports){
 module.exports = { "default": require("core-js/library/fn/number/max-safe-integer"), __esModule: true };
-},{"core-js/library/fn/number/max-safe-integer":238}],127:[function(require,module,exports){
+},{"core-js/library/fn/number/max-safe-integer":239}],128:[function(require,module,exports){
 module.exports = { "default": require("core-js/library/fn/object/assign"), __esModule: true };
-},{"core-js/library/fn/object/assign":239}],128:[function(require,module,exports){
+},{"core-js/library/fn/object/assign":240}],129:[function(require,module,exports){
 module.exports = { "default": require("core-js/library/fn/object/create"), __esModule: true };
-},{"core-js/library/fn/object/create":240}],129:[function(require,module,exports){
+},{"core-js/library/fn/object/create":241}],130:[function(require,module,exports){
 module.exports = { "default": require("core-js/library/fn/object/define-property"), __esModule: true };
-},{"core-js/library/fn/object/define-property":241}],130:[function(require,module,exports){
+},{"core-js/library/fn/object/define-property":242}],131:[function(require,module,exports){
 module.exports = { "default": require("core-js/library/fn/object/get-own-property-descriptor"), __esModule: true };
-},{"core-js/library/fn/object/get-own-property-descriptor":242}],131:[function(require,module,exports){
+},{"core-js/library/fn/object/get-own-property-descriptor":243}],132:[function(require,module,exports){
 module.exports = { "default": require("core-js/library/fn/object/get-own-property-names"), __esModule: true };
-},{"core-js/library/fn/object/get-own-property-names":243}],132:[function(require,module,exports){
+},{"core-js/library/fn/object/get-own-property-names":244}],133:[function(require,module,exports){
 module.exports = { "default": require("core-js/library/fn/object/get-own-property-symbols"), __esModule: true };
-},{"core-js/library/fn/object/get-own-property-symbols":244}],133:[function(require,module,exports){
+},{"core-js/library/fn/object/get-own-property-symbols":245}],134:[function(require,module,exports){
 module.exports = { "default": require("core-js/library/fn/object/keys"), __esModule: true };
-},{"core-js/library/fn/object/keys":245}],134:[function(require,module,exports){
+},{"core-js/library/fn/object/keys":246}],135:[function(require,module,exports){
 module.exports = { "default": require("core-js/library/fn/object/set-prototype-of"), __esModule: true };
-},{"core-js/library/fn/object/set-prototype-of":246}],135:[function(require,module,exports){
+},{"core-js/library/fn/object/set-prototype-of":247}],136:[function(require,module,exports){
 module.exports = { "default": require("core-js/library/fn/symbol"), __esModule: true };
-},{"core-js/library/fn/symbol":248}],136:[function(require,module,exports){
+},{"core-js/library/fn/symbol":249}],137:[function(require,module,exports){
 module.exports = { "default": require("core-js/library/fn/symbol/for"), __esModule: true };
-},{"core-js/library/fn/symbol/for":247}],137:[function(require,module,exports){
+},{"core-js/library/fn/symbol/for":248}],138:[function(require,module,exports){
 "use strict";
 
 exports["default"] = function (instance, Constructor) {
@@ -15611,7 +15655,7 @@ exports["default"] = function (instance, Constructor) {
 };
 
 exports.__esModule = true;
-},{}],138:[function(require,module,exports){
+},{}],139:[function(require,module,exports){
 "use strict";
 
 var _Object$getOwnPropertyNames = require("babel-runtime/core-js/object/get-own-property-names")["default"];
@@ -15637,7 +15681,7 @@ exports["default"] = function (obj, defaults) {
 };
 
 exports.__esModule = true;
-},{"babel-runtime/core-js/object/define-property":129,"babel-runtime/core-js/object/get-own-property-descriptor":130,"babel-runtime/core-js/object/get-own-property-names":131}],139:[function(require,module,exports){
+},{"babel-runtime/core-js/object/define-property":130,"babel-runtime/core-js/object/get-own-property-descriptor":131,"babel-runtime/core-js/object/get-own-property-names":132}],140:[function(require,module,exports){
 "use strict";
 
 var _Object$create = require("babel-runtime/core-js/object/create")["default"];
@@ -15661,7 +15705,7 @@ exports["default"] = function (subClass, superClass) {
 };
 
 exports.__esModule = true;
-},{"babel-runtime/core-js/object/create":128,"babel-runtime/core-js/object/set-prototype-of":134}],140:[function(require,module,exports){
+},{"babel-runtime/core-js/object/create":129,"babel-runtime/core-js/object/set-prototype-of":135}],141:[function(require,module,exports){
 "use strict";
 
 exports["default"] = function (obj, defaults) {
@@ -15671,7 +15715,7 @@ exports["default"] = function (obj, defaults) {
 };
 
 exports.__esModule = true;
-},{}],141:[function(require,module,exports){
+},{}],142:[function(require,module,exports){
 "use strict";
 
 exports["default"] = function (obj) {
@@ -15681,7 +15725,7 @@ exports["default"] = function (obj) {
 };
 
 exports.__esModule = true;
-},{}],142:[function(require,module,exports){
+},{}],143:[function(require,module,exports){
 "use strict";
 
 exports["default"] = function (obj) {
@@ -15702,7 +15746,7 @@ exports["default"] = function (obj) {
 };
 
 exports.__esModule = true;
-},{}],143:[function(require,module,exports){
+},{}],144:[function(require,module,exports){
 "use strict";
 
 exports["default"] = function (obj) {
@@ -15710,7 +15754,7 @@ exports["default"] = function (obj) {
 };
 
 exports.__esModule = true;
-},{}],144:[function(require,module,exports){
+},{}],145:[function(require,module,exports){
 "use strict";
 
 var _Symbol = require("babel-runtime/core-js/symbol")["default"];
@@ -15847,7 +15891,7 @@ var templateVisitor = {
   }
 };
 module.exports = exports["default"];
-},{"babel-runtime/core-js/symbol":135,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-traverse":147,"babel-types":201,"babylon":205,"lodash/lang/cloneDeep":414,"lodash/object/has":430}],145:[function(require,module,exports){
+},{"babel-runtime/core-js/symbol":136,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-traverse":148,"babel-types":202,"babylon":206,"lodash/lang/cloneDeep":415,"lodash/object/has":431}],146:[function(require,module,exports){
 (function (process){
 "use strict";
 
@@ -16055,7 +16099,7 @@ var TraversalContext = (function () {
 exports["default"] = TraversalContext;
 module.exports = exports["default"];
 }).call(this,require('_process'))
-},{"./path":155,"_process":448,"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/class-call-check":137,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],146:[function(require,module,exports){
+},{"./path":156,"_process":449,"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/class-call-check":138,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],147:[function(require,module,exports){
 "use strict";
 
 var _classCallCheck = require("babel-runtime/helpers/class-call-check")["default"];
@@ -16071,7 +16115,7 @@ var Hub = function Hub(file, options) {
 
 exports["default"] = Hub;
 module.exports = exports["default"];
-},{"babel-runtime/helpers/class-call-check":137}],147:[function(require,module,exports){
+},{"babel-runtime/helpers/class-call-check":138}],148:[function(require,module,exports){
 "use strict";
 
 var _getIterator = require("babel-runtime/core-js/get-iterator")["default"];
@@ -16288,7 +16332,7 @@ traverse.hasType = function (tree /*: Object*/, scope /*: Object*/, type /*: Obj
 
   return state.has;
 };
-},{"./context":145,"./hub":146,"./path":155,"./scope":167,"./visitors":169,"babel-messages":66,"babel-runtime/core-js/get-iterator":124,"babel-runtime/core-js/object/get-own-property-symbols":132,"babel-runtime/helpers/interop-require":143,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201,"lodash/collection/includes":343}],148:[function(require,module,exports){
+},{"./context":146,"./hub":147,"./path":156,"./scope":168,"./visitors":170,"babel-messages":67,"babel-runtime/core-js/get-iterator":125,"babel-runtime/core-js/object/get-own-property-symbols":133,"babel-runtime/helpers/interop-require":144,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202,"lodash/collection/includes":344}],149:[function(require,module,exports){
 // This file contains that retrieve or validate anything related to the current paths ancestry.
 
 "use strict";
@@ -16576,7 +16620,7 @@ function inShadow(key /*:: ?*/) {
   } while (path = path.parentPath);
   return null;
 }
-},{"./index":155,"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],149:[function(require,module,exports){
+},{"./index":156,"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],150:[function(require,module,exports){
 // This file contains methods responsible for dealing with comments.
 
 /**
@@ -16633,13 +16677,13 @@ function addComments(type /*: string*/, comments /*: Array*/) {
     node[key] = comments;
   }
 }
-},{}],150:[function(require,module,exports){
+},{}],151:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
 var PATH_CACHE_KEY = "_paths";exports.PATH_CACHE_KEY = PATH_CACHE_KEY;
 //Symbol();
-},{}],151:[function(require,module,exports){
+},{}],152:[function(require,module,exports){
 // This file contains methods responsible for maintaining a TraversalContext.
 
 "use strict";
@@ -16920,7 +16964,7 @@ function requeue() {
     context.maybeQueue(path);
   }
 }
-},{"../index":147,"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/interop-require-default":141}],152:[function(require,module,exports){
+},{"../index":148,"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/interop-require-default":142}],153:[function(require,module,exports){
 // This file contains methods that convert the path node into another node or some other type of data.
 
 "use strict";
@@ -16971,7 +17015,7 @@ function arrowFunctionToShadowed() {
   node.type = "FunctionExpression";
   node.shadow = node.shadow || true;
 }
-},{"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],153:[function(require,module,exports){
+},{"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],154:[function(require,module,exports){
 (function (global){
 "use strict";
 
@@ -17333,7 +17377,7 @@ function evaluate() /*: { confident: boolean; value: any }*/ {
   }
 }
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"babel-runtime/core-js/get-iterator":124}],154:[function(require,module,exports){
+},{"babel-runtime/core-js/get-iterator":125}],155:[function(require,module,exports){
 // This file contains methods responsible for dealing with/retrieving children or siblings.
 
 "use strict";
@@ -17504,7 +17548,7 @@ function getBindingIdentifiers(duplicates /*:: ?*/) {
 function getOuterBindingIdentifiers(duplicates /*:: ?*/) {
   return t.getOuterBindingIdentifiers(this.node, duplicates);
 }
-},{"./index":155,"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],155:[function(require,module,exports){
+},{"./index":156,"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],156:[function(require,module,exports){
 "use strict";
 
 var _classCallCheck = require("babel-runtime/helpers/class-call-check")["default"];
@@ -17756,7 +17800,7 @@ for (var type in virtualTypes) {
   if (_ret2 === "continue") continue;
 }
 module.exports = exports["default"];
-},{"../index":147,"../scope":167,"./ancestry":148,"./comments":149,"./constants":150,"./context":151,"./conversion":152,"./evaluation":153,"./family":154,"./inference":156,"./introspection":159,"./lib/virtual-types":162,"./modification":163,"./removal":164,"./replacement":165,"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/class-call-check":137,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201,"debug":315,"invariant":329,"lodash/object/assign":427}],156:[function(require,module,exports){
+},{"../index":148,"../scope":168,"./ancestry":149,"./comments":150,"./constants":151,"./context":152,"./conversion":153,"./evaluation":154,"./family":155,"./inference":157,"./introspection":160,"./lib/virtual-types":163,"./modification":164,"./removal":165,"./replacement":166,"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/class-call-check":138,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202,"debug":316,"invariant":330,"lodash/object/assign":428}],157:[function(require,module,exports){
 "use strict";
 
 var _getIterator = require("babel-runtime/core-js/get-iterator")["default"];
@@ -17904,7 +17948,7 @@ function isGenericType(genericName /*: string*/) /*: boolean*/ {
   var type = this.getTypeAnnotation();
   return t.isGenericTypeAnnotation(type) && t.isIdentifier(type.id, { name: genericName });
 }
-},{"./inferers":158,"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],157:[function(require,module,exports){
+},{"./inferers":159,"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],158:[function(require,module,exports){
 "use strict";
 
 var _getIterator = require("babel-runtime/core-js/get-iterator")["default"];
@@ -18127,7 +18171,7 @@ function getConditionalAnnotation(path, name) {
   }
 }
 module.exports = exports["default"];
-},{"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],158:[function(require,module,exports){
+},{"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],159:[function(require,module,exports){
 "use strict";
 
 var _interopRequireWildcard = require("babel-runtime/helpers/interop-require-wildcard")["default"];
@@ -18321,7 +18365,7 @@ function resolveCall(callee) {
     }
   }
 }
-},{"./inferer-reference":157,"babel-runtime/helpers/interop-require":143,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],159:[function(require,module,exports){
+},{"./inferer-reference":158,"babel-runtime/helpers/interop-require":144,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],160:[function(require,module,exports){
 // This file contains methods responsible for introspecting the current path for certain values.
 
 "use strict";
@@ -18814,7 +18858,7 @@ function _resolve(dangerous, /*:: ?*/resolved /*:: ?*/) /*: ?NodePath*/ {
       }
     }
 }
-},{"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201,"lodash/collection/includes":343}],160:[function(require,module,exports){
+},{"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202,"lodash/collection/includes":344}],161:[function(require,module,exports){
 "use strict";
 
 var _classCallCheck = require("babel-runtime/helpers/class-call-check")["default"];
@@ -18975,7 +19019,7 @@ var PathHoister = (function () {
 
 exports["default"] = PathHoister;
 module.exports = exports["default"];
-},{"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/class-call-check":137,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],161:[function(require,module,exports){
+},{"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/class-call-check":138,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],162:[function(require,module,exports){
 // this file contains hooks that handle ancestry cleanup of parent nodes when removing children
 
 /**
@@ -19041,7 +19085,7 @@ var hooks = [function (self, parent) {
   }
 }];
 exports.hooks = hooks;
-},{}],162:[function(require,module,exports){
+},{}],163:[function(require,module,exports){
 "use strict";
 
 var _interopRequireWildcard = require("babel-runtime/helpers/interop-require-wildcard")["default"];
@@ -19195,7 +19239,7 @@ var Flow = {
   }
 };
 exports.Flow = Flow;
-},{"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],163:[function(require,module,exports){
+},{"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],164:[function(require,module,exports){
 // This file contains methods that modify the path/node in some ways.
 
 "use strict";
@@ -19481,7 +19525,7 @@ function hoist() {
   var hoister = new _libHoister2["default"](this, scope);
   return hoister.run();
 }
-},{"./constants":150,"./index":155,"./lib/hoister":160,"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],164:[function(require,module,exports){
+},{"./constants":151,"./index":156,"./lib/hoister":161,"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],165:[function(require,module,exports){
 // This file contains methods responsible for removing a node.
 
 "use strict";
@@ -19551,7 +19595,7 @@ function _assertUnremoved() {
     throw this.buildCodeFrameError("NodePath has been removed so is read-only.");
   }
 }
-},{"./lib/removal-hooks":161,"babel-runtime/core-js/get-iterator":124}],165:[function(require,module,exports){
+},{"./lib/removal-hooks":162,"babel-runtime/core-js/get-iterator":125}],166:[function(require,module,exports){
 // This file contains methods responsible for replacing a node with another.
 
 "use strict";
@@ -19847,7 +19891,7 @@ function replaceInline(nodes /*: Object | Array<Object>*/) {
     return this.replaceWith(nodes);
   }
 }
-},{"../index":147,"./index":155,"babel-code-frame":10,"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201,"babylon":170}],166:[function(require,module,exports){
+},{"../index":148,"./index":156,"babel-code-frame":11,"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202,"babylon":171}],167:[function(require,module,exports){
 "use strict";
 
 var _classCallCheck = require("babel-runtime/helpers/class-call-check")["default"];
@@ -19945,7 +19989,7 @@ var Binding = (function () {
 
 exports["default"] = Binding;
 module.exports = exports["default"];
-},{"babel-runtime/helpers/class-call-check":137}],167:[function(require,module,exports){
+},{"babel-runtime/helpers/class-call-check":138}],168:[function(require,module,exports){
 "use strict";
 
 var _classCallCheck = require("babel-runtime/helpers/class-call-check")["default"];
@@ -21177,7 +21221,7 @@ module.exports = exports["default"];
 /**
  * Variables available in current context.
  */
-},{"../index":147,"./binding":166,"./lib/renamer":168,"babel-messages":66,"babel-runtime/core-js/get-iterator":124,"babel-runtime/core-js/object/create":128,"babel-runtime/core-js/symbol":135,"babel-runtime/helpers/class-call-check":137,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201,"globals":325,"lodash/collection/includes":343,"lodash/object/defaults":428,"repeating":469}],168:[function(require,module,exports){
+},{"../index":148,"./binding":167,"./lib/renamer":169,"babel-messages":67,"babel-runtime/core-js/get-iterator":125,"babel-runtime/core-js/object/create":129,"babel-runtime/core-js/symbol":136,"babel-runtime/helpers/class-call-check":138,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202,"globals":326,"lodash/collection/includes":344,"lodash/object/defaults":429,"repeating":470}],169:[function(require,module,exports){
 "use strict";
 
 var _classCallCheck = require("babel-runtime/helpers/class-call-check")["default"];
@@ -21331,7 +21375,7 @@ var Renamer = (function () {
 
 exports["default"] = Renamer;
 module.exports = exports["default"];
-},{"../binding":166,"babel-runtime/helpers/class-call-check":137,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201}],169:[function(require,module,exports){
+},{"../binding":167,"babel-runtime/helpers/class-call-check":138,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202}],170:[function(require,module,exports){
 "use strict";
 
 var _getIterator = require("babel-runtime/core-js/get-iterator")["default"];
@@ -21684,7 +21728,7 @@ function mergePair(dest, src) {
     dest[key] = [].concat(dest[key] || [], src[key]);
   }
 }
-},{"./path/lib/virtual-types":162,"babel-messages":66,"babel-runtime/core-js/get-iterator":124,"babel-runtime/core-js/object/keys":133,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-types":201,"lodash/lang/clone":413}],170:[function(require,module,exports){
+},{"./path/lib/virtual-types":163,"babel-messages":67,"babel-runtime/core-js/get-iterator":125,"babel-runtime/core-js/object/keys":134,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-types":202,"lodash/lang/clone":414}],171:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -21733,7 +21777,7 @@ function parse(input, options) {
 }
 
 exports.tokTypes = _types.types;
-},{"./parser":174,"./parser/comments":172,"./parser/expression":173,"./parser/location":175,"./parser/lval":176,"./parser/node":177,"./parser/statement":178,"./parser/util":179,"./plugins/flow":180,"./plugins/jsx":181,"./tokenizer":184,"./tokenizer/context":183,"./tokenizer/types":186}],171:[function(require,module,exports){
+},{"./parser":175,"./parser/comments":173,"./parser/expression":174,"./parser/location":176,"./parser/lval":177,"./parser/node":178,"./parser/statement":179,"./parser/util":180,"./plugins/flow":181,"./plugins/jsx":182,"./tokenizer":185,"./tokenizer/context":184,"./tokenizer/types":187}],172:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -21767,7 +21811,7 @@ function getOptions(opts) {
   }
   return options;
 }
-},{}],172:[function(require,module,exports){
+},{}],173:[function(require,module,exports){
 "use strict";
 
 var _index = require("./index");
@@ -21931,7 +21975,7 @@ pp.processComment = function (node) {
 
   stack.push(node);
 };
-},{"./index":174}],173:[function(require,module,exports){
+},{"./index":175}],174:[function(require,module,exports){
 "use strict";
 
 var _types = require("../tokenizer/types");
@@ -23001,7 +23045,7 @@ pp.parseYield = function () {
   }
   return this.finishNode(node, "YieldExpression");
 };
-},{"../tokenizer/types":186,"../util/identifier":187,"./index":174}],174:[function(require,module,exports){
+},{"../tokenizer/types":187,"../util/identifier":188,"./index":175}],175:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -23104,7 +23148,7 @@ var Parser = function (_Tokenizer) {
 }(_tokenizer2.default);
 
 exports.default = Parser;
-},{"../options":171,"../tokenizer":184,"../util/identifier":187}],175:[function(require,module,exports){
+},{"../options":172,"../tokenizer":185,"../util/identifier":188}],176:[function(require,module,exports){
 "use strict";
 
 var _location = require("../util/location");
@@ -23131,7 +23175,7 @@ pp.raise = function (pos, message) {
   err.loc = loc;
   throw err;
 };
-},{"../util/location":188,"./index":174}],176:[function(require,module,exports){
+},{"../util/location":189,"./index":175}],177:[function(require,module,exports){
 "use strict";
 
 var _types = require("../tokenizer/types");
@@ -23438,7 +23482,7 @@ pp.checkLVal = function (expr, isBinding, checkClashes) {
       this.raise(expr.start, (isBinding ? "Binding" : "Assigning to") + " rvalue");
   }
 };
-},{"../tokenizer/types":186,"../util/identifier":187,"./index":174}],177:[function(require,module,exports){
+},{"../tokenizer/types":187,"../util/identifier":188,"./index":175}],178:[function(require,module,exports){
 "use strict";
 
 var _index = require("./index");
@@ -23509,7 +23553,7 @@ pp.finishNode = function (node, type) {
 pp.finishNodeAt = function (node, type, pos, loc) {
   return finishNodeAt.call(this, node, type, pos, loc);
 };
-},{"../util/location":188,"./index":174}],178:[function(require,module,exports){
+},{"../util/location":189,"./index":175}],179:[function(require,module,exports){
 "use strict";
 
 var _types = require("../tokenizer/types");
@@ -24553,7 +24597,7 @@ pp.parseImportSpecifierDefault = function (id, startPos, startLoc) {
   this.checkLVal(node.local, true);
   return this.finishNode(node, "ImportDefaultSpecifier");
 };
-},{"../tokenizer/types":186,"../util/whitespace":189,"./index":174}],179:[function(require,module,exports){
+},{"../tokenizer/types":187,"../util/whitespace":190,"./index":175}],180:[function(require,module,exports){
 "use strict";
 
 var _types = require("../tokenizer/types");
@@ -24646,7 +24690,7 @@ pp.unexpected = function (pos) {
 
   this.raise(pos != null ? pos : this.state.start, message);
 };
-},{"../tokenizer/types":186,"../util/whitespace":189,"./index":174}],180:[function(require,module,exports){
+},{"../tokenizer/types":187,"../util/whitespace":190,"./index":175}],181:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -25840,7 +25884,7 @@ pp.typeCastToParameter = function (node) {
 
   return this.finishNodeAt(node.expression, node.expression.type, node.typeAnnotation.end, node.typeAnnotation.loc.end);
 };
-},{"../parser":174,"../tokenizer/context":183,"../tokenizer/types":186}],181:[function(require,module,exports){
+},{"../parser":175,"../tokenizer/context":184,"../tokenizer/types":187}],182:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -26323,7 +26367,7 @@ pp.jsxParseElement = function () {
   this.next();
   return this.jsxParseElementAt(startPos, startLoc);
 };
-},{"../../parser":174,"../../tokenizer/context":183,"../../tokenizer/types":186,"../../util/identifier":187,"../../util/whitespace":189,"./xhtml":182}],182:[function(require,module,exports){
+},{"../../parser":175,"../../tokenizer/context":184,"../../tokenizer/types":187,"../../util/identifier":188,"../../util/whitespace":190,"./xhtml":183}],183:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -26582,7 +26626,7 @@ exports.default = {
   hearts: "♥",
   diams: "♦"
 };
-},{}],183:[function(require,module,exports){
+},{}],184:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -26682,7 +26726,7 @@ _types.types.backQuote.updateContext = function () {
   }
   this.state.exprAllowed = false;
 };
-},{"../util/whitespace":189,"./types":186}],184:[function(require,module,exports){
+},{"../util/whitespace":190,"./types":187}],185:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -27564,7 +27608,7 @@ var Tokenizer = function () {
 }();
 
 exports.default = Tokenizer;
-},{"../util/identifier":187,"../util/location":188,"../util/whitespace":189,"./context":183,"./state":185,"./types":186}],185:[function(require,module,exports){
+},{"../util/identifier":188,"../util/location":189,"../util/whitespace":190,"./context":184,"./state":186,"./types":187}],186:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -27705,7 +27749,7 @@ var State = function () {
 }();
 
 exports.default = State;
-},{"../util/location":188,"./context":183,"./types":186}],186:[function(require,module,exports){
+},{"../util/location":189,"./context":184,"./types":187}],187:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -27863,7 +27907,7 @@ kw("instanceof", { beforeExpr: true, binop: 7 });
 kw("typeof", { beforeExpr: true, prefix: true, startsExpr: true });
 kw("void", { beforeExpr: true, prefix: true, startsExpr: true });
 kw("delete", { beforeExpr: true, prefix: true, startsExpr: true });
-},{}],187:[function(require,module,exports){
+},{}],188:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -27960,7 +28004,7 @@ function isIdentifierChar(code) {
   if (code <= 0xffff) return code >= 0xaa && nonASCIIidentifier.test(String.fromCharCode(code));
   return isInAstralSet(code, astralIdentifierStartCodes) || isInAstralSet(code, astralIdentifierCodes);
 }
-},{}],188:[function(require,module,exports){
+},{}],189:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -28006,7 +28050,7 @@ function getLineInfo(input, offset) {
     }
   }
 }
-},{"./whitespace":189}],189:[function(require,module,exports){
+},{"./whitespace":190}],190:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -28022,7 +28066,7 @@ function isNewLine(code) {
 }
 
 var nonASCIIwhitespace = exports.nonASCIIwhitespace = /[\u1680\u180e\u2000-\u200a\u202f\u205f\u3000\ufeff]/;
-},{}],190:[function(require,module,exports){
+},{}],191:[function(require,module,exports){
 "use strict";
 
 var _Symbol$for = require("babel-runtime/core-js/symbol/for")["default"];
@@ -28074,7 +28118,7 @@ var BLOCK_SCOPED_SYMBOL = _Symbol$for("var used to be block scoped");
 exports.BLOCK_SCOPED_SYMBOL = BLOCK_SCOPED_SYMBOL;
 var NOT_LOCAL_BINDING = _Symbol$for("should not be considered a local binding");
 exports.NOT_LOCAL_BINDING = NOT_LOCAL_BINDING;
-},{"babel-runtime/core-js/symbol/for":136}],191:[function(require,module,exports){
+},{"babel-runtime/core-js/symbol/for":137}],192:[function(require,module,exports){
 "use strict";
 
 var _getIterator = require("babel-runtime/core-js/get-iterator")["default"];
@@ -28444,7 +28488,7 @@ function valueToNode(value /*: any*/) /*: Object*/ {
 
   throw new Error("don't know how to turn this value into a node");
 }
-},{"./index":201,"babel-runtime/core-js/get-iterator":124,"babel-runtime/core-js/number/max-safe-integer":126,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"babel-traverse":147,"lodash/lang/isNumber":420,"lodash/lang/isPlainObject":422,"lodash/lang/isRegExp":423,"lodash/lang/isString":424}],192:[function(require,module,exports){
+},{"./index":202,"babel-runtime/core-js/get-iterator":125,"babel-runtime/core-js/number/max-safe-integer":127,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"babel-traverse":148,"lodash/lang/isNumber":421,"lodash/lang/isPlainObject":423,"lodash/lang/isRegExp":424,"lodash/lang/isString":425}],193:[function(require,module,exports){
 /* @flow */
 
 "use strict";
@@ -29145,7 +29189,7 @@ _index3["default"]("WithStatement", {
     }
   }
 });
-},{"../constants":190,"../index":201,"./index":196,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142}],193:[function(require,module,exports){
+},{"../constants":191,"../index":202,"./index":197,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143}],194:[function(require,module,exports){
 /* @flow */
 
 "use strict";
@@ -29493,7 +29537,7 @@ _index2["default"]("YieldExpression", {
     }
   }
 });
-},{"./index":196,"babel-runtime/helpers/interop-require-default":141}],194:[function(require,module,exports){
+},{"./index":197,"babel-runtime/helpers/interop-require-default":142}],195:[function(require,module,exports){
 /* @flow */
 
 "use strict";
@@ -29581,7 +29625,7 @@ _index2["default"]("SpreadProperty", {
     }
   }
 });
-},{"./index":196,"babel-runtime/helpers/interop-require-default":141}],195:[function(require,module,exports){
+},{"./index":197,"babel-runtime/helpers/interop-require-default":142}],196:[function(require,module,exports){
 /* @flow */
 
 "use strict";
@@ -29895,7 +29939,7 @@ _index2["default"]("VoidTypeAnnotation", {
     // todo
   }
 });
-},{"./index":196,"babel-runtime/helpers/interop-require-default":141}],196:[function(require,module,exports){
+},{"./index":197,"babel-runtime/helpers/interop-require-default":142}],197:[function(require,module,exports){
 /* @noflow */
 "use strict";
 
@@ -30141,7 +30185,7 @@ function defineType(type /*: string*/) {
 }
 
 var store = {};
-},{"../index":201,"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/interop-require-wildcard":142}],197:[function(require,module,exports){
+},{"../index":202,"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/interop-require-wildcard":143}],198:[function(require,module,exports){
 "use strict";
 
 require("./index");
@@ -30157,7 +30201,7 @@ require("./jsx");
 require("./misc");
 
 require("./experimental");
-},{"./core":192,"./es2015":193,"./experimental":194,"./flow":195,"./index":196,"./jsx":198,"./misc":199}],198:[function(require,module,exports){
+},{"./core":193,"./es2015":194,"./experimental":195,"./flow":196,"./index":197,"./jsx":199,"./misc":200}],199:[function(require,module,exports){
 /* @flow */
 
 "use strict";
@@ -30297,7 +30341,7 @@ _index2["default"]("JSXText", {
     }
   }
 });
-},{"./index":196,"babel-runtime/helpers/interop-require-default":141}],199:[function(require,module,exports){
+},{"./index":197,"babel-runtime/helpers/interop-require-default":142}],200:[function(require,module,exports){
 /* @flow */
 
 "use strict";
@@ -30321,7 +30365,7 @@ _index2["default"]("ParenthesizedExpression", {
     }
   }
 });
-},{"./index":196,"babel-runtime/helpers/interop-require-default":141}],200:[function(require,module,exports){
+},{"./index":197,"babel-runtime/helpers/interop-require-default":142}],201:[function(require,module,exports){
 "use strict";
 
 var _interopRequireWildcard = require("babel-runtime/helpers/interop-require-wildcard")["default"];
@@ -30451,7 +30495,7 @@ function createTypeAnnotationBasedOnTypeof(type /*: string*/) {
     throw new Error("Invalid typeof value");
   }
 }
-},{"./index":201,"babel-runtime/helpers/interop-require-wildcard":142}],201:[function(require,module,exports){
+},{"./index":202,"babel-runtime/helpers/interop-require-wildcard":143}],202:[function(require,module,exports){
 /* @noflow */
 
 "use strict";
@@ -31035,7 +31079,7 @@ _defaults(exports, _interopExportWildcard(_converters, _defaults));
 var _flow = require("./flow");
 
 _defaults(exports, _interopExportWildcard(_flow, _defaults));
-},{"./constants":190,"./converters":191,"./definitions":196,"./definitions/init":197,"./flow":200,"./react":202,"./retrievers":203,"./validators":204,"babel-runtime/core-js/get-iterator":124,"babel-runtime/core-js/object/keys":133,"babel-runtime/helpers/defaults":138,"babel-runtime/helpers/interop-export-wildcard":140,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"lodash/array/compact":336,"lodash/array/uniq":339,"lodash/collection/each":341,"lodash/lang/clone":413,"to-fast-properties":488}],202:[function(require,module,exports){
+},{"./constants":191,"./converters":192,"./definitions":197,"./definitions/init":198,"./flow":201,"./react":203,"./retrievers":204,"./validators":205,"babel-runtime/core-js/get-iterator":125,"babel-runtime/core-js/object/keys":134,"babel-runtime/helpers/defaults":139,"babel-runtime/helpers/interop-export-wildcard":141,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"lodash/array/compact":337,"lodash/array/uniq":340,"lodash/collection/each":342,"lodash/lang/clone":414,"to-fast-properties":489}],203:[function(require,module,exports){
 /* @flow */
 
 "use strict";
@@ -31122,7 +31166,7 @@ function buildChildren(node /*: Object*/) /*: Array<Object>*/ {
 
   return elems;
 }
-},{"./index":201,"babel-runtime/helpers/interop-require-wildcard":142}],203:[function(require,module,exports){
+},{"./index":202,"babel-runtime/helpers/interop-require-wildcard":143}],204:[function(require,module,exports){
 /* @flow */
 
 "use strict";
@@ -31243,7 +31287,7 @@ getBindingIdentifiers.keys = {
 function getOuterBindingIdentifiers(node /*: Object*/, duplicates /*:: ?: boolean*/) /*: Object*/ {
   return getBindingIdentifiers(node, duplicates, true);
 }
-},{"./index":201,"babel-runtime/core-js/object/create":128,"babel-runtime/helpers/interop-require-wildcard":142}],204:[function(require,module,exports){
+},{"./index":202,"babel-runtime/core-js/object/create":129,"babel-runtime/helpers/interop-require-wildcard":143}],205:[function(require,module,exports){
 "use strict";
 
 var _getIterator = require("babel-runtime/core-js/get-iterator")["default"];
@@ -31511,7 +31555,7 @@ function isImmutable(node /*: Object*/) /*: boolean*/ {
 
   return false;
 }
-},{"./constants":190,"./index":201,"./retrievers":203,"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/interop-require-default":141,"babel-runtime/helpers/interop-require-wildcard":142,"esutils":323}],205:[function(require,module,exports){
+},{"./constants":191,"./index":202,"./retrievers":204,"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/interop-require-default":142,"babel-runtime/helpers/interop-require-wildcard":143,"esutils":324}],206:[function(require,module,exports){
 "use strict";
 
 var _interopRequireDefault = require("babel-runtime/helpers/interop-require-default")["default"];
@@ -31559,7 +31603,7 @@ function parse(input, options) {
 }
 
 exports.tokTypes = _tokenizerTypes.types;
-},{"./parser":209,"./parser/comments":207,"./parser/expression":208,"./parser/location":210,"./parser/lval":211,"./parser/node":212,"./parser/statement":213,"./parser/util":214,"./plugins/flow":215,"./plugins/jsx":216,"./tokenizer":219,"./tokenizer/context":218,"./tokenizer/types":221,"babel-runtime/helpers/interop-require-default":141}],206:[function(require,module,exports){
+},{"./parser":210,"./parser/comments":208,"./parser/expression":209,"./parser/location":211,"./parser/lval":212,"./parser/node":213,"./parser/statement":214,"./parser/util":215,"./plugins/flow":216,"./plugins/jsx":217,"./tokenizer":220,"./tokenizer/context":219,"./tokenizer/types":222,"babel-runtime/helpers/interop-require-default":142}],207:[function(require,module,exports){
 // A second optional argument can be given to further configure
 // the parser process. These options are recognized:
 
@@ -31594,7 +31638,7 @@ function getOptions(opts /*:: ?: Object*/) /*: Object*/ {
   }
   return options;
 }
-},{}],207:[function(require,module,exports){
+},{}],208:[function(require,module,exports){
 /* @flow */
 
 /**
@@ -31746,7 +31790,7 @@ pp.processComment = function (node) {
 
   stack.push(node);
 };
-},{"./index":209,"babel-runtime/helpers/interop-require-default":141}],208:[function(require,module,exports){
+},{"./index":210,"babel-runtime/helpers/interop-require-default":142}],209:[function(require,module,exports){
 // A recursive descent parser operates by defining functions for all
 // syntactic elements, and recursively calling those, each function
 // advancing the input stream and returning an AST node. Precedence
@@ -32796,7 +32840,7 @@ pp.parseYield = function () {
   }
   return this.finishNode(node, "YieldExpression");
 };
-},{"../tokenizer/types":221,"../util/identifier":222,"./index":209,"babel-runtime/core-js/get-iterator":124,"babel-runtime/core-js/object/create":128,"babel-runtime/helpers/interop-require-default":141}],209:[function(require,module,exports){
+},{"../tokenizer/types":222,"../util/identifier":223,"./index":210,"babel-runtime/core-js/get-iterator":125,"babel-runtime/core-js/object/create":129,"babel-runtime/helpers/interop-require-default":142}],210:[function(require,module,exports){
 /* @noflow */
 
 "use strict";
@@ -32901,7 +32945,7 @@ var Parser = (function (_Tokenizer) {
 })(_tokenizer2["default"]);
 
 exports["default"] = Parser;
-},{"../options":206,"../tokenizer":219,"../util/identifier":222,"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/class-call-check":137,"babel-runtime/helpers/inherits":139,"babel-runtime/helpers/interop-require-default":141}],210:[function(require,module,exports){
+},{"../options":207,"../tokenizer":220,"../util/identifier":223,"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/class-call-check":138,"babel-runtime/helpers/inherits":140,"babel-runtime/helpers/interop-require-default":142}],211:[function(require,module,exports){
 "use strict";
 
 var _interopRequireDefault = require("babel-runtime/helpers/interop-require-default")["default"];
@@ -32928,7 +32972,7 @@ pp.raise = function (pos, message) {
   err.loc = loc;
   throw err;
 };
-},{"../util/location":223,"./index":209,"babel-runtime/helpers/interop-require-default":141}],211:[function(require,module,exports){
+},{"../util/location":224,"./index":210,"babel-runtime/helpers/interop-require-default":142}],212:[function(require,module,exports){
 "use strict";
 
 var _getIterator = require("babel-runtime/core-js/get-iterator")["default"];
@@ -33228,7 +33272,7 @@ pp.checkLVal = function (expr, isBinding, checkClashes) {
       this.raise(expr.start, (isBinding ? "Binding" : "Assigning to") + " rvalue");
   }
 };
-},{"../tokenizer/types":221,"../util/identifier":222,"./index":209,"babel-runtime/core-js/get-iterator":124,"babel-runtime/helpers/interop-require-default":141}],212:[function(require,module,exports){
+},{"../tokenizer/types":222,"../util/identifier":223,"./index":210,"babel-runtime/core-js/get-iterator":125,"babel-runtime/helpers/interop-require-default":142}],213:[function(require,module,exports){
 "use strict";
 
 var _classCallCheck = require("babel-runtime/helpers/class-call-check")["default"];
@@ -33292,7 +33336,7 @@ pp.finishNode = function (node, type) {
 pp.finishNodeAt = function (node, type, pos, loc) {
   return finishNodeAt.call(this, node, type, pos, loc);
 };
-},{"../util/location":223,"./index":209,"babel-runtime/helpers/class-call-check":137,"babel-runtime/helpers/interop-require-default":141}],213:[function(require,module,exports){
+},{"../util/location":224,"./index":210,"babel-runtime/helpers/class-call-check":138,"babel-runtime/helpers/interop-require-default":142}],214:[function(require,module,exports){
 "use strict";
 
 var _Object$create = require("babel-runtime/core-js/object/create")["default"];
@@ -34312,7 +34356,7 @@ pp.parseImportSpecifierDefault = function (id, startPos, startLoc) {
   this.checkLVal(node.local, true);
   return this.finishNode(node, "ImportDefaultSpecifier");
 };
-},{"../tokenizer/types":221,"../util/whitespace":224,"./index":209,"babel-runtime/core-js/get-iterator":124,"babel-runtime/core-js/object/create":128,"babel-runtime/helpers/interop-require-default":141}],214:[function(require,module,exports){
+},{"../tokenizer/types":222,"../util/whitespace":225,"./index":210,"babel-runtime/core-js/get-iterator":125,"babel-runtime/core-js/object/create":129,"babel-runtime/helpers/interop-require-default":142}],215:[function(require,module,exports){
 /* @flow */
 
 "use strict";
@@ -34405,7 +34449,7 @@ pp.expect = function (type) {
 pp.unexpected = function (pos) {
   this.raise(pos != null ? pos : this.state.start, "Unexpected token");
 };
-},{"../tokenizer/types":221,"../util/whitespace":224,"./index":209,"babel-runtime/helpers/interop-require-default":141}],215:[function(require,module,exports){
+},{"../tokenizer/types":222,"../util/whitespace":225,"./index":210,"babel-runtime/helpers/interop-require-default":142}],216:[function(require,module,exports){
 "use strict";
 
 var _interopRequireDefault = require("babel-runtime/helpers/interop-require-default")["default"];
@@ -35428,7 +35472,7 @@ exports["default"] = function (instance) {
 };
 
 module.exports = exports["default"];
-},{"../parser":209,"../tokenizer/types":221,"babel-runtime/helpers/interop-require-default":141}],216:[function(require,module,exports){
+},{"../parser":210,"../tokenizer/types":222,"babel-runtime/helpers/interop-require-default":142}],217:[function(require,module,exports){
 "use strict";
 
 var _interopRequireDefault = require("babel-runtime/helpers/interop-require-default")["default"];
@@ -35893,7 +35937,7 @@ exports["default"] = function (instance) {
 };
 
 module.exports = exports["default"];
-},{"../../parser":209,"../../tokenizer/context":218,"../../tokenizer/types":221,"../../util/identifier":222,"../../util/whitespace":224,"./xhtml":217,"babel-runtime/helpers/interop-require-default":141}],217:[function(require,module,exports){
+},{"../../parser":210,"../../tokenizer/context":219,"../../tokenizer/types":222,"../../util/identifier":223,"../../util/whitespace":225,"./xhtml":218,"babel-runtime/helpers/interop-require-default":142}],218:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -36153,7 +36197,7 @@ exports["default"] = {
   diams: "♦"
 };
 module.exports = exports["default"];
-},{}],218:[function(require,module,exports){
+},{}],219:[function(require,module,exports){
 /* @flow */
 
 // The algorithm used to determine whether a regexp can appear at a
@@ -36258,7 +36302,7 @@ _types.types.backQuote.updateContext = function () {
   }
   this.state.exprAllowed = false;
 };
-},{"../util/whitespace":224,"./types":221,"babel-runtime/helpers/class-call-check":137}],219:[function(require,module,exports){
+},{"../util/whitespace":225,"./types":222,"babel-runtime/helpers/class-call-check":138}],220:[function(require,module,exports){
 "use strict";
 
 var _classCallCheck = require("babel-runtime/helpers/class-call-check")["default"];
@@ -37141,7 +37185,7 @@ var Tokenizer = (function () {
 })();
 
 exports["default"] = Tokenizer;
-},{"../util/identifier":222,"../util/location":223,"../util/whitespace":224,"./context":218,"./state":220,"./types":221,"babel-runtime/helpers/class-call-check":137,"babel-runtime/helpers/interop-require-default":141}],220:[function(require,module,exports){
+},{"../util/identifier":223,"../util/location":224,"../util/whitespace":225,"./context":219,"./state":221,"./types":222,"babel-runtime/helpers/class-call-check":138,"babel-runtime/helpers/interop-require-default":142}],221:[function(require,module,exports){
 "use strict";
 
 var _classCallCheck = require("babel-runtime/helpers/class-call-check")["default"];
@@ -37267,7 +37311,7 @@ module.exports = exports["default"];
 // escape sequences must not be interpreted as keywords.
 
 // TODO
-},{"../util/location":223,"./context":218,"./types":221,"babel-runtime/helpers/class-call-check":137}],221:[function(require,module,exports){
+},{"../util/location":224,"./context":219,"./types":222,"babel-runtime/helpers/class-call-check":138}],222:[function(require,module,exports){
 // ## Token types
 
 // The assignment of fine-grained, information-carrying type objects
@@ -37429,7 +37473,7 @@ kw("instanceof", { beforeExpr: true, binop: 7 });
 kw("typeof", { beforeExpr: true, prefix: true, startsExpr: true });
 kw("void", { beforeExpr: true, prefix: true, startsExpr: true });
 kw("delete", { beforeExpr: true, prefix: true, startsExpr: true });
-},{"babel-runtime/helpers/class-call-check":137}],222:[function(require,module,exports){
+},{"babel-runtime/helpers/class-call-check":138}],223:[function(require,module,exports){
 // This is a trick taken from Esprima. It turns out that, on
 // non-Chrome browsers, to check whether a string is in a set, a
 // predicate containing a big ugly `switch` statement is faster than
@@ -37526,7 +37570,7 @@ function isIdentifierChar(code) {
   if (code <= 0xffff) return code >= 0xaa && nonASCIIidentifier.test(String.fromCharCode(code));
   return isInAstralSet(code, astralIdentifierStartCodes) || isInAstralSet(code, astralIdentifierCodes);
 }
-},{}],223:[function(require,module,exports){
+},{}],224:[function(require,module,exports){
 "use strict";
 
 var _classCallCheck = require("babel-runtime/helpers/class-call-check")["default"];
@@ -37577,7 +37621,7 @@ function getLineInfo(input, offset) {
     }
   }
 }
-},{"./whitespace":224,"babel-runtime/helpers/class-call-check":137}],224:[function(require,module,exports){
+},{"./whitespace":225,"babel-runtime/helpers/class-call-check":138}],225:[function(require,module,exports){
 /* @flow */
 
 // Matches a whole line break (where CRLF is considered a single
@@ -37599,7 +37643,7 @@ function isNewLine(code /*: number*/) /*: boolean*/ {
 
 var nonASCIIwhitespace = /[\u1680\u180e\u2000-\u200a\u202f\u205f\u3000\ufeff]/;
 exports.nonASCIIwhitespace = nonASCIIwhitespace;
-},{}],225:[function(require,module,exports){
+},{}],226:[function(require,module,exports){
 module.exports = balanced;
 function balanced(a, b, str) {
   var r = range(a, b, str);
@@ -37651,7 +37695,7 @@ function range(a, b, str) {
   return result;
 }
 
-},{}],226:[function(require,module,exports){
+},{}],227:[function(require,module,exports){
 'use strict'
 
 exports.toByteArray = toByteArray
@@ -37762,7 +37806,7 @@ function fromByteArray (uint8) {
   return parts.join('')
 }
 
-},{}],227:[function(require,module,exports){
+},{}],228:[function(require,module,exports){
 var concatMap = require('concat-map');
 var balanced = require('balanced-match');
 
@@ -37955,9 +37999,9 @@ function expand(str, isTop) {
 }
 
 
-},{"balanced-match":225,"concat-map":234}],228:[function(require,module,exports){
+},{"balanced-match":226,"concat-map":235}],229:[function(require,module,exports){
 
-},{}],229:[function(require,module,exports){
+},{}],230:[function(require,module,exports){
 (function (global){
 /*!
  * The buffer module from node.js, for the browser.
@@ -39750,14 +39794,14 @@ function isnan (val) {
 }
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"base64-js":226,"ieee754":327,"isarray":230}],230:[function(require,module,exports){
+},{"base64-js":227,"ieee754":328,"isarray":231}],231:[function(require,module,exports){
 var toString = {}.toString;
 
 module.exports = Array.isArray || function (arr) {
   return toString.call(arr) == '[object Array]';
 };
 
-},{}],231:[function(require,module,exports){
+},{}],232:[function(require,module,exports){
 (function (process){
 'use strict';
 var escapeStringRegexp = require('escape-string-regexp');
@@ -39877,7 +39921,7 @@ module.exports.stripColor = stripAnsi;
 module.exports.supportsColor = supportsColor;
 
 }).call(this,require('_process'))
-},{"_process":448,"ansi-styles":8,"escape-string-regexp":319,"has-ansi":326,"strip-ansi":486,"supports-color":487}],232:[function(require,module,exports){
+},{"_process":449,"ansi-styles":9,"escape-string-regexp":320,"has-ansi":327,"strip-ansi":487,"supports-color":488}],233:[function(require,module,exports){
 /**
  * JavaScript matchers for parsing text with Complexion.
  *
@@ -41231,7 +41275,7 @@ module.exports.supportsColor = supportsColor;
 }));
 // fid-umd post-end
 
-},{}],233:[function(require,module,exports){
+},{}],234:[function(require,module,exports){
 /**
  * Scan through a string and turn it into tokens.
  *
@@ -41719,7 +41763,7 @@ module.exports.supportsColor = supportsColor;
 }));
 // fid-umd post-end
 
-},{}],234:[function(require,module,exports){
+},{}],235:[function(require,module,exports){
 module.exports = function (xs, fn) {
     var res = [];
     for (var i = 0; i < xs.length; i++) {
@@ -41734,7 +41778,7 @@ var isArray = Array.isArray || function (xs) {
     return Object.prototype.toString.call(xs) === '[object Array]';
 };
 
-},{}],235:[function(require,module,exports){
+},{}],236:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 var fs = require('fs');
@@ -41894,75 +41938,75 @@ Object.defineProperty(exports, 'mapFileCommentRegex', {
 });
 
 }).call(this,require("buffer").Buffer)
-},{"buffer":229,"fs":228,"path":443}],236:[function(require,module,exports){
+},{"buffer":230,"fs":229,"path":444}],237:[function(require,module,exports){
 require('../modules/web.dom.iterable');
 require('../modules/es6.string.iterator');
 module.exports = require('../modules/core.get-iterator');
-},{"../modules/core.get-iterator":299,"../modules/es6.string.iterator":309,"../modules/web.dom.iterable":312}],237:[function(require,module,exports){
+},{"../modules/core.get-iterator":300,"../modules/es6.string.iterator":310,"../modules/web.dom.iterable":313}],238:[function(require,module,exports){
 require('../modules/es6.object.to-string');
 require('../modules/es6.string.iterator');
 require('../modules/web.dom.iterable');
 require('../modules/es6.map');
 require('../modules/es7.map.to-json');
 module.exports = require('../modules/$.core').Map;
-},{"../modules/$.core":257,"../modules/es6.map":301,"../modules/es6.object.to-string":308,"../modules/es6.string.iterator":309,"../modules/es7.map.to-json":311,"../modules/web.dom.iterable":312}],238:[function(require,module,exports){
+},{"../modules/$.core":258,"../modules/es6.map":302,"../modules/es6.object.to-string":309,"../modules/es6.string.iterator":310,"../modules/es7.map.to-json":312,"../modules/web.dom.iterable":313}],239:[function(require,module,exports){
 require('../../modules/es6.number.max-safe-integer');
 module.exports = 0x1fffffffffffff;
-},{"../../modules/es6.number.max-safe-integer":302}],239:[function(require,module,exports){
+},{"../../modules/es6.number.max-safe-integer":303}],240:[function(require,module,exports){
 require('../../modules/es6.object.assign');
 module.exports = require('../../modules/$.core').Object.assign;
-},{"../../modules/$.core":257,"../../modules/es6.object.assign":303}],240:[function(require,module,exports){
+},{"../../modules/$.core":258,"../../modules/es6.object.assign":304}],241:[function(require,module,exports){
 var $ = require('../../modules/$');
 module.exports = function create(P, D){
   return $.create(P, D);
 };
-},{"../../modules/$":278}],241:[function(require,module,exports){
+},{"../../modules/$":279}],242:[function(require,module,exports){
 var $ = require('../../modules/$');
 module.exports = function defineProperty(it, key, desc){
   return $.setDesc(it, key, desc);
 };
-},{"../../modules/$":278}],242:[function(require,module,exports){
+},{"../../modules/$":279}],243:[function(require,module,exports){
 var $ = require('../../modules/$');
 require('../../modules/es6.object.get-own-property-descriptor');
 module.exports = function getOwnPropertyDescriptor(it, key){
   return $.getDesc(it, key);
 };
-},{"../../modules/$":278,"../../modules/es6.object.get-own-property-descriptor":304}],243:[function(require,module,exports){
+},{"../../modules/$":279,"../../modules/es6.object.get-own-property-descriptor":305}],244:[function(require,module,exports){
 var $ = require('../../modules/$');
 require('../../modules/es6.object.get-own-property-names');
 module.exports = function getOwnPropertyNames(it){
   return $.getNames(it);
 };
-},{"../../modules/$":278,"../../modules/es6.object.get-own-property-names":305}],244:[function(require,module,exports){
+},{"../../modules/$":279,"../../modules/es6.object.get-own-property-names":306}],245:[function(require,module,exports){
 require('../../modules/es6.symbol');
 module.exports = require('../../modules/$.core').Object.getOwnPropertySymbols;
-},{"../../modules/$.core":257,"../../modules/es6.symbol":310}],245:[function(require,module,exports){
+},{"../../modules/$.core":258,"../../modules/es6.symbol":311}],246:[function(require,module,exports){
 require('../../modules/es6.object.keys');
 module.exports = require('../../modules/$.core').Object.keys;
-},{"../../modules/$.core":257,"../../modules/es6.object.keys":306}],246:[function(require,module,exports){
+},{"../../modules/$.core":258,"../../modules/es6.object.keys":307}],247:[function(require,module,exports){
 require('../../modules/es6.object.set-prototype-of');
 module.exports = require('../../modules/$.core').Object.setPrototypeOf;
-},{"../../modules/$.core":257,"../../modules/es6.object.set-prototype-of":307}],247:[function(require,module,exports){
+},{"../../modules/$.core":258,"../../modules/es6.object.set-prototype-of":308}],248:[function(require,module,exports){
 require('../../modules/es6.symbol');
 module.exports = require('../../modules/$.core').Symbol['for'];
-},{"../../modules/$.core":257,"../../modules/es6.symbol":310}],248:[function(require,module,exports){
+},{"../../modules/$.core":258,"../../modules/es6.symbol":311}],249:[function(require,module,exports){
 require('../../modules/es6.symbol');
 require('../../modules/es6.object.to-string');
 module.exports = require('../../modules/$.core').Symbol;
-},{"../../modules/$.core":257,"../../modules/es6.object.to-string":308,"../../modules/es6.symbol":310}],249:[function(require,module,exports){
+},{"../../modules/$.core":258,"../../modules/es6.object.to-string":309,"../../modules/es6.symbol":311}],250:[function(require,module,exports){
 module.exports = function(it){
   if(typeof it != 'function')throw TypeError(it + ' is not a function!');
   return it;
 };
-},{}],250:[function(require,module,exports){
-module.exports = function(){ /* empty */ };
 },{}],251:[function(require,module,exports){
+module.exports = function(){ /* empty */ };
+},{}],252:[function(require,module,exports){
 var isObject = require('./$.is-object');
 module.exports = function(it){
   if(!isObject(it))throw TypeError(it + ' is not an object!');
   return it;
 };
-},{"./$.is-object":272}],252:[function(require,module,exports){
+},{"./$.is-object":273}],253:[function(require,module,exports){
 // getting tag from 19.1.3.6 Object.prototype.toString()
 var cof = require('./$.cof')
   , TAG = require('./$.wks')('toStringTag')
@@ -41979,13 +42023,13 @@ module.exports = function(it){
     // ES3 arguments fallback
     : (B = cof(O)) == 'Object' && typeof O.callee == 'function' ? 'Arguments' : B;
 };
-},{"./$.cof":253,"./$.wks":297}],253:[function(require,module,exports){
+},{"./$.cof":254,"./$.wks":298}],254:[function(require,module,exports){
 var toString = {}.toString;
 
 module.exports = function(it){
   return toString.call(it).slice(8, -1);
 };
-},{}],254:[function(require,module,exports){
+},{}],255:[function(require,module,exports){
 'use strict';
 var $            = require('./$')
   , hide         = require('./$.hide')
@@ -42145,7 +42189,7 @@ module.exports = {
     setSpecies(NAME);
   }
 };
-},{"./$":278,"./$.ctx":258,"./$.defined":259,"./$.descriptors":260,"./$.for-of":264,"./$.has":267,"./$.hide":268,"./$.is-object":272,"./$.iter-define":275,"./$.iter-step":276,"./$.redefine-all":284,"./$.set-species":287,"./$.strict-new":290,"./$.uid":296}],255:[function(require,module,exports){
+},{"./$":279,"./$.ctx":259,"./$.defined":260,"./$.descriptors":261,"./$.for-of":265,"./$.has":268,"./$.hide":269,"./$.is-object":273,"./$.iter-define":276,"./$.iter-step":277,"./$.redefine-all":285,"./$.set-species":288,"./$.strict-new":291,"./$.uid":297}],256:[function(require,module,exports){
 // https://github.com/DavidBruant/Map-Set.prototype.toJSON
 var forOf   = require('./$.for-of')
   , classof = require('./$.classof');
@@ -42157,7 +42201,7 @@ module.exports = function(NAME){
     return arr;
   };
 };
-},{"./$.classof":252,"./$.for-of":264}],256:[function(require,module,exports){
+},{"./$.classof":253,"./$.for-of":265}],257:[function(require,module,exports){
 'use strict';
 var $              = require('./$')
   , global         = require('./$.global')
@@ -42213,10 +42257,10 @@ module.exports = function(NAME, wrapper, methods, common, IS_MAP, IS_WEAK){
 
   return C;
 };
-},{"./$":278,"./$.descriptors":260,"./$.export":262,"./$.fails":263,"./$.for-of":264,"./$.global":266,"./$.hide":268,"./$.is-object":272,"./$.redefine-all":284,"./$.set-to-string-tag":288,"./$.strict-new":290}],257:[function(require,module,exports){
+},{"./$":279,"./$.descriptors":261,"./$.export":263,"./$.fails":264,"./$.for-of":265,"./$.global":267,"./$.hide":269,"./$.is-object":273,"./$.redefine-all":285,"./$.set-to-string-tag":289,"./$.strict-new":291}],258:[function(require,module,exports){
 var core = module.exports = {version: '1.2.6'};
 if(typeof __e == 'number')__e = core; // eslint-disable-line no-undef
-},{}],258:[function(require,module,exports){
+},{}],259:[function(require,module,exports){
 // optional / simple context binding
 var aFunction = require('./$.a-function');
 module.exports = function(fn, that, length){
@@ -42237,18 +42281,18 @@ module.exports = function(fn, that, length){
     return fn.apply(that, arguments);
   };
 };
-},{"./$.a-function":249}],259:[function(require,module,exports){
+},{"./$.a-function":250}],260:[function(require,module,exports){
 // 7.2.1 RequireObjectCoercible(argument)
 module.exports = function(it){
   if(it == undefined)throw TypeError("Can't call method on  " + it);
   return it;
 };
-},{}],260:[function(require,module,exports){
+},{}],261:[function(require,module,exports){
 // Thank's IE8 for his funny defineProperty
 module.exports = !require('./$.fails')(function(){
   return Object.defineProperty({}, 'a', {get: function(){ return 7; }}).a != 7;
 });
-},{"./$.fails":263}],261:[function(require,module,exports){
+},{"./$.fails":264}],262:[function(require,module,exports){
 // all enumerable object keys, includes symbols
 var $ = require('./$');
 module.exports = function(it){
@@ -42263,7 +42307,7 @@ module.exports = function(it){
   }
   return keys;
 };
-},{"./$":278}],262:[function(require,module,exports){
+},{"./$":279}],263:[function(require,module,exports){
 var global    = require('./$.global')
   , core      = require('./$.core')
   , ctx       = require('./$.ctx')
@@ -42310,7 +42354,7 @@ $export.P = 8;  // proto
 $export.B = 16; // bind
 $export.W = 32; // wrap
 module.exports = $export;
-},{"./$.core":257,"./$.ctx":258,"./$.global":266}],263:[function(require,module,exports){
+},{"./$.core":258,"./$.ctx":259,"./$.global":267}],264:[function(require,module,exports){
 module.exports = function(exec){
   try {
     return !!exec();
@@ -42318,7 +42362,7 @@ module.exports = function(exec){
     return true;
   }
 };
-},{}],264:[function(require,module,exports){
+},{}],265:[function(require,module,exports){
 var ctx         = require('./$.ctx')
   , call        = require('./$.iter-call')
   , isArrayIter = require('./$.is-array-iter')
@@ -42338,7 +42382,7 @@ module.exports = function(iterable, entries, fn, that){
     call(iterator, f, step.value, entries);
   }
 };
-},{"./$.an-object":251,"./$.ctx":258,"./$.is-array-iter":270,"./$.iter-call":273,"./$.to-length":294,"./core.get-iterator-method":298}],265:[function(require,module,exports){
+},{"./$.an-object":252,"./$.ctx":259,"./$.is-array-iter":271,"./$.iter-call":274,"./$.to-length":295,"./core.get-iterator-method":299}],266:[function(require,module,exports){
 // fallback for IE11 buggy Object.getOwnPropertyNames with iframe and window
 var toIObject = require('./$.to-iobject')
   , getNames  = require('./$').getNames
@@ -42359,17 +42403,17 @@ module.exports.get = function getOwnPropertyNames(it){
   if(windowNames && toString.call(it) == '[object Window]')return getWindowNames(it);
   return getNames(toIObject(it));
 };
-},{"./$":278,"./$.to-iobject":293}],266:[function(require,module,exports){
+},{"./$":279,"./$.to-iobject":294}],267:[function(require,module,exports){
 // https://github.com/zloirock/core-js/issues/86#issuecomment-115759028
 var global = module.exports = typeof window != 'undefined' && window.Math == Math
   ? window : typeof self != 'undefined' && self.Math == Math ? self : Function('return this')();
 if(typeof __g == 'number')__g = global; // eslint-disable-line no-undef
-},{}],267:[function(require,module,exports){
+},{}],268:[function(require,module,exports){
 var hasOwnProperty = {}.hasOwnProperty;
 module.exports = function(it, key){
   return hasOwnProperty.call(it, key);
 };
-},{}],268:[function(require,module,exports){
+},{}],269:[function(require,module,exports){
 var $          = require('./$')
   , createDesc = require('./$.property-desc');
 module.exports = require('./$.descriptors') ? function(object, key, value){
@@ -42378,13 +42422,13 @@ module.exports = require('./$.descriptors') ? function(object, key, value){
   object[key] = value;
   return object;
 };
-},{"./$":278,"./$.descriptors":260,"./$.property-desc":283}],269:[function(require,module,exports){
+},{"./$":279,"./$.descriptors":261,"./$.property-desc":284}],270:[function(require,module,exports){
 // fallback for non-array-like ES3 and non-enumerable old V8 strings
 var cof = require('./$.cof');
 module.exports = Object('z').propertyIsEnumerable(0) ? Object : function(it){
   return cof(it) == 'String' ? it.split('') : Object(it);
 };
-},{"./$.cof":253}],270:[function(require,module,exports){
+},{"./$.cof":254}],271:[function(require,module,exports){
 // check on default Array iterator
 var Iterators  = require('./$.iterators')
   , ITERATOR   = require('./$.wks')('iterator')
@@ -42393,17 +42437,17 @@ var Iterators  = require('./$.iterators')
 module.exports = function(it){
   return it !== undefined && (Iterators.Array === it || ArrayProto[ITERATOR] === it);
 };
-},{"./$.iterators":277,"./$.wks":297}],271:[function(require,module,exports){
+},{"./$.iterators":278,"./$.wks":298}],272:[function(require,module,exports){
 // 7.2.2 IsArray(argument)
 var cof = require('./$.cof');
 module.exports = Array.isArray || function(arg){
   return cof(arg) == 'Array';
 };
-},{"./$.cof":253}],272:[function(require,module,exports){
+},{"./$.cof":254}],273:[function(require,module,exports){
 module.exports = function(it){
   return typeof it === 'object' ? it !== null : typeof it === 'function';
 };
-},{}],273:[function(require,module,exports){
+},{}],274:[function(require,module,exports){
 // call something on iterator step with safe closing on error
 var anObject = require('./$.an-object');
 module.exports = function(iterator, fn, value, entries){
@@ -42416,7 +42460,7 @@ module.exports = function(iterator, fn, value, entries){
     throw e;
   }
 };
-},{"./$.an-object":251}],274:[function(require,module,exports){
+},{"./$.an-object":252}],275:[function(require,module,exports){
 'use strict';
 var $              = require('./$')
   , descriptor     = require('./$.property-desc')
@@ -42430,7 +42474,7 @@ module.exports = function(Constructor, NAME, next){
   Constructor.prototype = $.create(IteratorPrototype, {next: descriptor(1, next)});
   setToStringTag(Constructor, NAME + ' Iterator');
 };
-},{"./$":278,"./$.hide":268,"./$.property-desc":283,"./$.set-to-string-tag":288,"./$.wks":297}],275:[function(require,module,exports){
+},{"./$":279,"./$.hide":269,"./$.property-desc":284,"./$.set-to-string-tag":289,"./$.wks":298}],276:[function(require,module,exports){
 'use strict';
 var LIBRARY        = require('./$.library')
   , $export        = require('./$.export')
@@ -42497,13 +42541,13 @@ module.exports = function(Base, NAME, Constructor, next, DEFAULT, IS_SET, FORCED
   }
   return methods;
 };
-},{"./$":278,"./$.export":262,"./$.has":267,"./$.hide":268,"./$.iter-create":274,"./$.iterators":277,"./$.library":280,"./$.redefine":285,"./$.set-to-string-tag":288,"./$.wks":297}],276:[function(require,module,exports){
+},{"./$":279,"./$.export":263,"./$.has":268,"./$.hide":269,"./$.iter-create":275,"./$.iterators":278,"./$.library":281,"./$.redefine":286,"./$.set-to-string-tag":289,"./$.wks":298}],277:[function(require,module,exports){
 module.exports = function(done, value){
   return {value: value, done: !!done};
 };
-},{}],277:[function(require,module,exports){
-module.exports = {};
 },{}],278:[function(require,module,exports){
+module.exports = {};
+},{}],279:[function(require,module,exports){
 var $Object = Object;
 module.exports = {
   create:     $Object.create,
@@ -42517,7 +42561,7 @@ module.exports = {
   getSymbols: $Object.getOwnPropertySymbols,
   each:       [].forEach
 };
-},{}],279:[function(require,module,exports){
+},{}],280:[function(require,module,exports){
 var $         = require('./$')
   , toIObject = require('./$.to-iobject');
 module.exports = function(object, el){
@@ -42528,9 +42572,9 @@ module.exports = function(object, el){
     , key;
   while(length > index)if(O[key = keys[index++]] === el)return key;
 };
-},{"./$":278,"./$.to-iobject":293}],280:[function(require,module,exports){
+},{"./$":279,"./$.to-iobject":294}],281:[function(require,module,exports){
 module.exports = true;
-},{}],281:[function(require,module,exports){
+},{}],282:[function(require,module,exports){
 // 19.1.2.1 Object.assign(target, source, ...)
 var $        = require('./$')
   , toObject = require('./$.to-object')
@@ -42564,7 +42608,7 @@ module.exports = require('./$.fails')(function(){
   }
   return T;
 } : Object.assign;
-},{"./$":278,"./$.fails":263,"./$.iobject":269,"./$.to-object":295}],282:[function(require,module,exports){
+},{"./$":279,"./$.fails":264,"./$.iobject":270,"./$.to-object":296}],283:[function(require,module,exports){
 // most Object methods by ES6 should accept primitives
 var $export = require('./$.export')
   , core    = require('./$.core')
@@ -42575,7 +42619,7 @@ module.exports = function(KEY, exec){
   exp[KEY] = exec(fn);
   $export($export.S + $export.F * fails(function(){ fn(1); }), 'Object', exp);
 };
-},{"./$.core":257,"./$.export":262,"./$.fails":263}],283:[function(require,module,exports){
+},{"./$.core":258,"./$.export":263,"./$.fails":264}],284:[function(require,module,exports){
 module.exports = function(bitmap, value){
   return {
     enumerable  : !(bitmap & 1),
@@ -42584,15 +42628,15 @@ module.exports = function(bitmap, value){
     value       : value
   };
 };
-},{}],284:[function(require,module,exports){
+},{}],285:[function(require,module,exports){
 var redefine = require('./$.redefine');
 module.exports = function(target, src){
   for(var key in src)redefine(target, key, src[key]);
   return target;
 };
-},{"./$.redefine":285}],285:[function(require,module,exports){
+},{"./$.redefine":286}],286:[function(require,module,exports){
 module.exports = require('./$.hide');
-},{"./$.hide":268}],286:[function(require,module,exports){
+},{"./$.hide":269}],287:[function(require,module,exports){
 // Works with __proto__ only. Old v8 can't work with null proto objects.
 /* eslint-disable no-proto */
 var getDesc  = require('./$').getDesc
@@ -42619,7 +42663,7 @@ module.exports = {
     }({}, false) : undefined),
   check: check
 };
-},{"./$":278,"./$.an-object":251,"./$.ctx":258,"./$.is-object":272}],287:[function(require,module,exports){
+},{"./$":279,"./$.an-object":252,"./$.ctx":259,"./$.is-object":273}],288:[function(require,module,exports){
 'use strict';
 var core        = require('./$.core')
   , $           = require('./$')
@@ -42633,7 +42677,7 @@ module.exports = function(KEY){
     get: function(){ return this; }
   });
 };
-},{"./$":278,"./$.core":257,"./$.descriptors":260,"./$.wks":297}],288:[function(require,module,exports){
+},{"./$":279,"./$.core":258,"./$.descriptors":261,"./$.wks":298}],289:[function(require,module,exports){
 var def = require('./$').setDesc
   , has = require('./$.has')
   , TAG = require('./$.wks')('toStringTag');
@@ -42641,19 +42685,19 @@ var def = require('./$').setDesc
 module.exports = function(it, tag, stat){
   if(it && !has(it = stat ? it : it.prototype, TAG))def(it, TAG, {configurable: true, value: tag});
 };
-},{"./$":278,"./$.has":267,"./$.wks":297}],289:[function(require,module,exports){
+},{"./$":279,"./$.has":268,"./$.wks":298}],290:[function(require,module,exports){
 var global = require('./$.global')
   , SHARED = '__core-js_shared__'
   , store  = global[SHARED] || (global[SHARED] = {});
 module.exports = function(key){
   return store[key] || (store[key] = {});
 };
-},{"./$.global":266}],290:[function(require,module,exports){
+},{"./$.global":267}],291:[function(require,module,exports){
 module.exports = function(it, Constructor, name){
   if(!(it instanceof Constructor))throw TypeError(name + ": use the 'new' operator!");
   return it;
 };
-},{}],291:[function(require,module,exports){
+},{}],292:[function(require,module,exports){
 var toInteger = require('./$.to-integer')
   , defined   = require('./$.defined');
 // true  -> String#at
@@ -42671,40 +42715,40 @@ module.exports = function(TO_STRING){
       : TO_STRING ? s.slice(i, i + 2) : (a - 0xd800 << 10) + (b - 0xdc00) + 0x10000;
   };
 };
-},{"./$.defined":259,"./$.to-integer":292}],292:[function(require,module,exports){
+},{"./$.defined":260,"./$.to-integer":293}],293:[function(require,module,exports){
 // 7.1.4 ToInteger
 var ceil  = Math.ceil
   , floor = Math.floor;
 module.exports = function(it){
   return isNaN(it = +it) ? 0 : (it > 0 ? floor : ceil)(it);
 };
-},{}],293:[function(require,module,exports){
+},{}],294:[function(require,module,exports){
 // to indexed object, toObject with fallback for non-array-like ES3 strings
 var IObject = require('./$.iobject')
   , defined = require('./$.defined');
 module.exports = function(it){
   return IObject(defined(it));
 };
-},{"./$.defined":259,"./$.iobject":269}],294:[function(require,module,exports){
+},{"./$.defined":260,"./$.iobject":270}],295:[function(require,module,exports){
 // 7.1.15 ToLength
 var toInteger = require('./$.to-integer')
   , min       = Math.min;
 module.exports = function(it){
   return it > 0 ? min(toInteger(it), 0x1fffffffffffff) : 0; // pow(2, 53) - 1 == 9007199254740991
 };
-},{"./$.to-integer":292}],295:[function(require,module,exports){
+},{"./$.to-integer":293}],296:[function(require,module,exports){
 // 7.1.13 ToObject(argument)
 var defined = require('./$.defined');
 module.exports = function(it){
   return Object(defined(it));
 };
-},{"./$.defined":259}],296:[function(require,module,exports){
+},{"./$.defined":260}],297:[function(require,module,exports){
 var id = 0
   , px = Math.random();
 module.exports = function(key){
   return 'Symbol('.concat(key === undefined ? '' : key, ')_', (++id + px).toString(36));
 };
-},{}],297:[function(require,module,exports){
+},{}],298:[function(require,module,exports){
 var store  = require('./$.shared')('wks')
   , uid    = require('./$.uid')
   , Symbol = require('./$.global').Symbol;
@@ -42712,7 +42756,7 @@ module.exports = function(name){
   return store[name] || (store[name] =
     Symbol && Symbol[name] || (Symbol || uid)('Symbol.' + name));
 };
-},{"./$.global":266,"./$.shared":289,"./$.uid":296}],298:[function(require,module,exports){
+},{"./$.global":267,"./$.shared":290,"./$.uid":297}],299:[function(require,module,exports){
 var classof   = require('./$.classof')
   , ITERATOR  = require('./$.wks')('iterator')
   , Iterators = require('./$.iterators');
@@ -42721,7 +42765,7 @@ module.exports = require('./$.core').getIteratorMethod = function(it){
     || it['@@iterator']
     || Iterators[classof(it)];
 };
-},{"./$.classof":252,"./$.core":257,"./$.iterators":277,"./$.wks":297}],299:[function(require,module,exports){
+},{"./$.classof":253,"./$.core":258,"./$.iterators":278,"./$.wks":298}],300:[function(require,module,exports){
 var anObject = require('./$.an-object')
   , get      = require('./core.get-iterator-method');
 module.exports = require('./$.core').getIterator = function(it){
@@ -42729,7 +42773,7 @@ module.exports = require('./$.core').getIterator = function(it){
   if(typeof iterFn != 'function')throw TypeError(it + ' is not iterable!');
   return anObject(iterFn.call(it));
 };
-},{"./$.an-object":251,"./$.core":257,"./core.get-iterator-method":298}],300:[function(require,module,exports){
+},{"./$.an-object":252,"./$.core":258,"./core.get-iterator-method":299}],301:[function(require,module,exports){
 'use strict';
 var addToUnscopables = require('./$.add-to-unscopables')
   , step             = require('./$.iter-step')
@@ -42764,7 +42808,7 @@ Iterators.Arguments = Iterators.Array;
 addToUnscopables('keys');
 addToUnscopables('values');
 addToUnscopables('entries');
-},{"./$.add-to-unscopables":250,"./$.iter-define":275,"./$.iter-step":276,"./$.iterators":277,"./$.to-iobject":293}],301:[function(require,module,exports){
+},{"./$.add-to-unscopables":251,"./$.iter-define":276,"./$.iter-step":277,"./$.iterators":278,"./$.to-iobject":294}],302:[function(require,module,exports){
 'use strict';
 var strong = require('./$.collection-strong');
 
@@ -42782,17 +42826,17 @@ require('./$.collection')('Map', function(get){
     return strong.def(this, key === 0 ? 0 : key, value);
   }
 }, strong, true);
-},{"./$.collection":256,"./$.collection-strong":254}],302:[function(require,module,exports){
+},{"./$.collection":257,"./$.collection-strong":255}],303:[function(require,module,exports){
 // 20.1.2.6 Number.MAX_SAFE_INTEGER
 var $export = require('./$.export');
 
 $export($export.S, 'Number', {MAX_SAFE_INTEGER: 0x1fffffffffffff});
-},{"./$.export":262}],303:[function(require,module,exports){
+},{"./$.export":263}],304:[function(require,module,exports){
 // 19.1.3.1 Object.assign(target, source)
 var $export = require('./$.export');
 
 $export($export.S + $export.F, 'Object', {assign: require('./$.object-assign')});
-},{"./$.export":262,"./$.object-assign":281}],304:[function(require,module,exports){
+},{"./$.export":263,"./$.object-assign":282}],305:[function(require,module,exports){
 // 19.1.2.6 Object.getOwnPropertyDescriptor(O, P)
 var toIObject = require('./$.to-iobject');
 
@@ -42801,12 +42845,12 @@ require('./$.object-sap')('getOwnPropertyDescriptor', function($getOwnPropertyDe
     return $getOwnPropertyDescriptor(toIObject(it), key);
   };
 });
-},{"./$.object-sap":282,"./$.to-iobject":293}],305:[function(require,module,exports){
+},{"./$.object-sap":283,"./$.to-iobject":294}],306:[function(require,module,exports){
 // 19.1.2.7 Object.getOwnPropertyNames(O)
 require('./$.object-sap')('getOwnPropertyNames', function(){
   return require('./$.get-names').get;
 });
-},{"./$.get-names":265,"./$.object-sap":282}],306:[function(require,module,exports){
+},{"./$.get-names":266,"./$.object-sap":283}],307:[function(require,module,exports){
 // 19.1.2.14 Object.keys(O)
 var toObject = require('./$.to-object');
 
@@ -42815,13 +42859,13 @@ require('./$.object-sap')('keys', function($keys){
     return $keys(toObject(it));
   };
 });
-},{"./$.object-sap":282,"./$.to-object":295}],307:[function(require,module,exports){
+},{"./$.object-sap":283,"./$.to-object":296}],308:[function(require,module,exports){
 // 19.1.3.19 Object.setPrototypeOf(O, proto)
 var $export = require('./$.export');
 $export($export.S, 'Object', {setPrototypeOf: require('./$.set-proto').set});
-},{"./$.export":262,"./$.set-proto":286}],308:[function(require,module,exports){
-arguments[4][228][0].apply(exports,arguments)
-},{"dup":228}],309:[function(require,module,exports){
+},{"./$.export":263,"./$.set-proto":287}],309:[function(require,module,exports){
+arguments[4][229][0].apply(exports,arguments)
+},{"dup":229}],310:[function(require,module,exports){
 'use strict';
 var $at  = require('./$.string-at')(true);
 
@@ -42839,7 +42883,7 @@ require('./$.iter-define')(String, 'String', function(iterated){
   this._i += point.length;
   return {value: point, done: false};
 });
-},{"./$.iter-define":275,"./$.string-at":291}],310:[function(require,module,exports){
+},{"./$.iter-define":276,"./$.string-at":292}],311:[function(require,module,exports){
 'use strict';
 // ECMAScript 6 symbols shim
 var $              = require('./$')
@@ -43067,23 +43111,23 @@ setToStringTag($Symbol, 'Symbol');
 setToStringTag(Math, 'Math', true);
 // 24.3.3 JSON[@@toStringTag]
 setToStringTag(global.JSON, 'JSON', true);
-},{"./$":278,"./$.an-object":251,"./$.descriptors":260,"./$.enum-keys":261,"./$.export":262,"./$.fails":263,"./$.get-names":265,"./$.global":266,"./$.has":267,"./$.is-array":271,"./$.keyof":279,"./$.library":280,"./$.property-desc":283,"./$.redefine":285,"./$.set-to-string-tag":288,"./$.shared":289,"./$.to-iobject":293,"./$.uid":296,"./$.wks":297}],311:[function(require,module,exports){
+},{"./$":279,"./$.an-object":252,"./$.descriptors":261,"./$.enum-keys":262,"./$.export":263,"./$.fails":264,"./$.get-names":266,"./$.global":267,"./$.has":268,"./$.is-array":272,"./$.keyof":280,"./$.library":281,"./$.property-desc":284,"./$.redefine":286,"./$.set-to-string-tag":289,"./$.shared":290,"./$.to-iobject":294,"./$.uid":297,"./$.wks":298}],312:[function(require,module,exports){
 // https://github.com/DavidBruant/Map-Set.prototype.toJSON
 var $export  = require('./$.export');
 
 $export($export.P, 'Map', {toJSON: require('./$.collection-to-json')('Map')});
-},{"./$.collection-to-json":255,"./$.export":262}],312:[function(require,module,exports){
+},{"./$.collection-to-json":256,"./$.export":263}],313:[function(require,module,exports){
 require('./es6.array.iterator');
 var Iterators = require('./$.iterators');
 Iterators.NodeList = Iterators.HTMLCollection = Iterators.Array;
-},{"./$.iterators":277,"./es6.array.iterator":300}],313:[function(require,module,exports){
+},{"./$.iterators":278,"./es6.array.iterator":301}],314:[function(require,module,exports){
 module.exports = Date.now || now
 
 function now() {
     return new Date().getTime()
 }
 
-},{}],314:[function(require,module,exports){
+},{}],315:[function(require,module,exports){
 
 /**
  * Module dependencies.
@@ -43138,7 +43182,7 @@ module.exports = function debounce(func, wait, immediate){
   };
 };
 
-},{"date-now":313}],315:[function(require,module,exports){
+},{"date-now":314}],316:[function(require,module,exports){
 
 /**
  * This is the web browser implementation of `debug()`.
@@ -43308,7 +43352,7 @@ function localstorage(){
   } catch (e) {}
 }
 
-},{"./debug":316}],316:[function(require,module,exports){
+},{"./debug":317}],317:[function(require,module,exports){
 
 /**
  * This is the common logic for both the Node.js and web browser
@@ -43507,7 +43551,7 @@ function coerce(val) {
   return val;
 }
 
-},{"ms":441}],317:[function(require,module,exports){
+},{"ms":442}],318:[function(require,module,exports){
 (function (process){
 
 /**
@@ -43720,7 +43764,7 @@ function createWritableStdioStream (fd) {
 exports.enable(load());
 
 }).call(this,require('_process'))
-},{"./debug":316,"_process":448,"fs":228,"net":228,"tty":490,"util":492}],318:[function(require,module,exports){
+},{"./debug":317,"_process":449,"fs":229,"net":229,"tty":491,"util":493}],319:[function(require,module,exports){
 'use strict';
 var repeating = require('repeating');
 
@@ -43841,7 +43885,7 @@ module.exports = function (str) {
 	};
 };
 
-},{"repeating":469}],319:[function(require,module,exports){
+},{"repeating":470}],320:[function(require,module,exports){
 'use strict';
 
 var matchOperatorsRe = /[|\\{}()[\]^$+*?.]/g;
@@ -43854,7 +43898,7 @@ module.exports = function (str) {
 	return str.replace(matchOperatorsRe, '\\$&');
 };
 
-},{}],320:[function(require,module,exports){
+},{}],321:[function(require,module,exports){
 /*
   Copyright (C) 2013 Yusuke Suzuki <utatane.tea@gmail.com>
 
@@ -44000,7 +44044,7 @@ module.exports = function (str) {
 }());
 /* vim: set sw=4 ts=4 et tw=80 : */
 
-},{}],321:[function(require,module,exports){
+},{}],322:[function(require,module,exports){
 /*
   Copyright (C) 2013-2014 Yusuke Suzuki <utatane.tea@gmail.com>
   Copyright (C) 2014 Ivan Nikulin <ifaaan@gmail.com>
@@ -44137,7 +44181,7 @@ module.exports = function (str) {
 }());
 /* vim: set sw=4 ts=4 et tw=80 : */
 
-},{}],322:[function(require,module,exports){
+},{}],323:[function(require,module,exports){
 /*
   Copyright (C) 2013 Yusuke Suzuki <utatane.tea@gmail.com>
 
@@ -44304,7 +44348,7 @@ module.exports = function (str) {
 }());
 /* vim: set sw=4 ts=4 et tw=80 : */
 
-},{"./code":321}],323:[function(require,module,exports){
+},{"./code":322}],324:[function(require,module,exports){
 /*
   Copyright (C) 2013 Yusuke Suzuki <utatane.tea@gmail.com>
 
@@ -44339,7 +44383,7 @@ module.exports = function (str) {
 }());
 /* vim: set sw=4 ts=4 et tw=80 : */
 
-},{"./ast":320,"./code":321,"./keyword":322}],324:[function(require,module,exports){
+},{"./ast":321,"./code":322,"./keyword":323}],325:[function(require,module,exports){
 module.exports={
 	"builtin": {
 		"Array": false,
@@ -45586,16 +45630,16 @@ module.exports={
 	}
 }
 
-},{}],325:[function(require,module,exports){
+},{}],326:[function(require,module,exports){
 module.exports = require('./globals.json');
 
-},{"./globals.json":324}],326:[function(require,module,exports){
+},{"./globals.json":325}],327:[function(require,module,exports){
 'use strict';
 var ansiRegex = require('ansi-regex');
 var re = new RegExp(ansiRegex().source); // remove the `g` flag
 module.exports = re.test.bind(re);
 
-},{"ansi-regex":7}],327:[function(require,module,exports){
+},{"ansi-regex":8}],328:[function(require,module,exports){
 exports.read = function (buffer, offset, isLE, mLen, nBytes) {
   var e, m
   var eLen = nBytes * 8 - mLen - 1
@@ -45681,7 +45725,7 @@ exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
   buffer[offset + i - d] |= s * 128
 }
 
-},{}],328:[function(require,module,exports){
+},{}],329:[function(require,module,exports){
 if (typeof Object.create === 'function') {
   // implementation from standard node.js 'util' module
   module.exports = function inherits(ctor, superCtor) {
@@ -45706,7 +45750,7 @@ if (typeof Object.create === 'function') {
   }
 }
 
-},{}],329:[function(require,module,exports){
+},{}],330:[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2015, Facebook, Inc.
@@ -45761,7 +45805,7 @@ var invariant = function(condition, format, a, b, c, d, e, f) {
 module.exports = invariant;
 
 }).call(this,require('_process'))
-},{"_process":448}],330:[function(require,module,exports){
+},{"_process":449}],331:[function(require,module,exports){
 'use strict';
 var numberIsNan = require('number-is-nan');
 
@@ -45769,7 +45813,7 @@ module.exports = Number.isFinite || function (val) {
 	return !(typeof val !== 'number' || numberIsNan(val) || val === Infinity || val === -Infinity);
 };
 
-},{"number-is-nan":442}],331:[function(require,module,exports){
+},{"number-is-nan":443}],332:[function(require,module,exports){
 // https://github.com/paulmillr/es6-shim
 // http://people.mozilla.org/~jorendorff/es6-draft.html#sec-number.isinteger
 var isFinite = require("is-finite");
@@ -45779,7 +45823,7 @@ module.exports = Number.isInteger || function(val) {
     Math.floor(val) === val;
 };
 
-},{"is-finite":330}],332:[function(require,module,exports){
+},{"is-finite":331}],333:[function(require,module,exports){
 // Copyright 2014, 2015 Simon Lydell
 // X11 (“MIT”) Licensed. (See LICENSE.)
 
@@ -45800,7 +45844,7 @@ module.exports.matchToToken = function(match) {
   return token
 }
 
-},{}],333:[function(require,module,exports){
+},{}],334:[function(require,module,exports){
 // json5.js
 // Modern JSON. See README.md for details.
 //
@@ -46556,7 +46600,7 @@ JSON5.stringify = function (obj, replacer, space) {
     return internalStringify(topLevelHolder, '', true);
 };
 
-},{}],334:[function(require,module,exports){
+},{}],335:[function(require,module,exports){
 module.exports = leftpad;
 
 function leftpad (str, len, ch) {
@@ -46575,7 +46619,7 @@ function leftpad (str, len, ch) {
   return str;
 }
 
-},{}],335:[function(require,module,exports){
+},{}],336:[function(require,module,exports){
 // Copyright 2014, 2015 Simon Lydell
 // X11 (“MIT”) Licensed. (See LICENSE.)
 
@@ -46609,7 +46653,7 @@ function lineNumbers(code, options) {
 
 module.exports = lineNumbers
 
-},{"left-pad":334}],336:[function(require,module,exports){
+},{"left-pad":335}],337:[function(require,module,exports){
 /**
  * Creates an array with all falsey values removed. The values `false`, `null`,
  * `0`, `""`, `undefined`, and `NaN` are falsey.
@@ -46641,7 +46685,7 @@ function compact(array) {
 
 module.exports = compact;
 
-},{}],337:[function(require,module,exports){
+},{}],338:[function(require,module,exports){
 /**
  * Gets the last element of `array`.
  *
@@ -46662,7 +46706,7 @@ function last(array) {
 
 module.exports = last;
 
-},{}],338:[function(require,module,exports){
+},{}],339:[function(require,module,exports){
 var baseIndexOf = require('../internal/baseIndexOf');
 
 /** Used for native method references. */
@@ -46716,7 +46760,7 @@ function pull() {
 
 module.exports = pull;
 
-},{"../internal/baseIndexOf":364}],339:[function(require,module,exports){
+},{"../internal/baseIndexOf":365}],340:[function(require,module,exports){
 var baseCallback = require('../internal/baseCallback'),
     baseUniq = require('../internal/baseUniq'),
     isIterateeCall = require('../internal/isIterateeCall'),
@@ -46789,13 +46833,13 @@ function uniq(array, isSorted, iteratee, thisArg) {
 
 module.exports = uniq;
 
-},{"../internal/baseCallback":355,"../internal/baseUniq":378,"../internal/isIterateeCall":404,"../internal/sortedUniq":410}],340:[function(require,module,exports){
+},{"../internal/baseCallback":356,"../internal/baseUniq":379,"../internal/isIterateeCall":405,"../internal/sortedUniq":411}],341:[function(require,module,exports){
 module.exports = require('./includes');
 
-},{"./includes":343}],341:[function(require,module,exports){
+},{"./includes":344}],342:[function(require,module,exports){
 module.exports = require('./forEach');
 
-},{"./forEach":342}],342:[function(require,module,exports){
+},{"./forEach":343}],343:[function(require,module,exports){
 var arrayEach = require('../internal/arrayEach'),
     baseEach = require('../internal/baseEach'),
     createForEach = require('../internal/createForEach');
@@ -46834,7 +46878,7 @@ var forEach = createForEach(arrayEach, baseEach);
 
 module.exports = forEach;
 
-},{"../internal/arrayEach":349,"../internal/baseEach":359,"../internal/createForEach":390}],343:[function(require,module,exports){
+},{"../internal/arrayEach":350,"../internal/baseEach":360,"../internal/createForEach":391}],344:[function(require,module,exports){
 var baseIndexOf = require('../internal/baseIndexOf'),
     getLength = require('../internal/getLength'),
     isArray = require('../lang/isArray'),
@@ -46893,7 +46937,7 @@ function includes(collection, target, fromIndex, guard) {
 
 module.exports = includes;
 
-},{"../internal/baseIndexOf":364,"../internal/getLength":395,"../internal/isIterateeCall":404,"../internal/isLength":406,"../lang/isArray":416,"../lang/isString":424,"../object/values":435}],344:[function(require,module,exports){
+},{"../internal/baseIndexOf":365,"../internal/getLength":396,"../internal/isIterateeCall":405,"../internal/isLength":407,"../lang/isArray":417,"../lang/isString":425,"../object/values":436}],345:[function(require,module,exports){
 var arrayMap = require('../internal/arrayMap'),
     baseCallback = require('../internal/baseCallback'),
     baseMap = require('../internal/baseMap'),
@@ -46963,7 +47007,7 @@ function map(collection, iteratee, thisArg) {
 
 module.exports = map;
 
-},{"../internal/arrayMap":350,"../internal/baseCallback":355,"../internal/baseMap":368,"../lang/isArray":416}],345:[function(require,module,exports){
+},{"../internal/arrayMap":351,"../internal/baseCallback":356,"../internal/baseMap":369,"../lang/isArray":417}],346:[function(require,module,exports){
 var baseCallback = require('../internal/baseCallback'),
     baseMap = require('../internal/baseMap'),
     baseSortBy = require('../internal/baseSortBy'),
@@ -47036,7 +47080,7 @@ function sortBy(collection, iteratee, thisArg) {
 
 module.exports = sortBy;
 
-},{"../internal/baseCallback":355,"../internal/baseMap":368,"../internal/baseSortBy":376,"../internal/compareAscending":384,"../internal/isIterateeCall":404}],346:[function(require,module,exports){
+},{"../internal/baseCallback":356,"../internal/baseMap":369,"../internal/baseSortBy":377,"../internal/compareAscending":385,"../internal/isIterateeCall":405}],347:[function(require,module,exports){
 /** Used as the `TypeError` message for "Functions" methods. */
 var FUNC_ERROR_TEXT = 'Expected a function';
 
@@ -47096,7 +47140,7 @@ function restParam(func, start) {
 
 module.exports = restParam;
 
-},{}],347:[function(require,module,exports){
+},{}],348:[function(require,module,exports){
 (function (global){
 var cachePush = require('./cachePush'),
     getNative = require('./getNative');
@@ -47129,7 +47173,7 @@ SetCache.prototype.push = cachePush;
 module.exports = SetCache;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./cachePush":383,"./getNative":397}],348:[function(require,module,exports){
+},{"./cachePush":384,"./getNative":398}],349:[function(require,module,exports){
 /**
  * Copies the values of `source` to `array`.
  *
@@ -47151,7 +47195,7 @@ function arrayCopy(source, array) {
 
 module.exports = arrayCopy;
 
-},{}],349:[function(require,module,exports){
+},{}],350:[function(require,module,exports){
 /**
  * A specialized version of `_.forEach` for arrays without support for callback
  * shorthands and `this` binding.
@@ -47175,7 +47219,7 @@ function arrayEach(array, iteratee) {
 
 module.exports = arrayEach;
 
-},{}],350:[function(require,module,exports){
+},{}],351:[function(require,module,exports){
 /**
  * A specialized version of `_.map` for arrays without support for callback
  * shorthands and `this` binding.
@@ -47198,7 +47242,7 @@ function arrayMap(array, iteratee) {
 
 module.exports = arrayMap;
 
-},{}],351:[function(require,module,exports){
+},{}],352:[function(require,module,exports){
 /**
  * A specialized version of `_.some` for arrays without support for callback
  * shorthands and `this` binding.
@@ -47223,7 +47267,7 @@ function arraySome(array, predicate) {
 
 module.exports = arraySome;
 
-},{}],352:[function(require,module,exports){
+},{}],353:[function(require,module,exports){
 /**
  * Used by `_.defaults` to customize its `_.assign` use.
  *
@@ -47238,7 +47282,7 @@ function assignDefaults(objectValue, sourceValue) {
 
 module.exports = assignDefaults;
 
-},{}],353:[function(require,module,exports){
+},{}],354:[function(require,module,exports){
 var keys = require('../object/keys');
 
 /**
@@ -47272,7 +47316,7 @@ function assignWith(object, source, customizer) {
 
 module.exports = assignWith;
 
-},{"../object/keys":431}],354:[function(require,module,exports){
+},{"../object/keys":432}],355:[function(require,module,exports){
 var baseCopy = require('./baseCopy'),
     keys = require('../object/keys');
 
@@ -47293,7 +47337,7 @@ function baseAssign(object, source) {
 
 module.exports = baseAssign;
 
-},{"../object/keys":431,"./baseCopy":358}],355:[function(require,module,exports){
+},{"../object/keys":432,"./baseCopy":359}],356:[function(require,module,exports){
 var baseMatches = require('./baseMatches'),
     baseMatchesProperty = require('./baseMatchesProperty'),
     bindCallback = require('./bindCallback'),
@@ -47330,7 +47374,7 @@ function baseCallback(func, thisArg, argCount) {
 
 module.exports = baseCallback;
 
-},{"../utility/identity":438,"../utility/property":439,"./baseMatches":369,"./baseMatchesProperty":370,"./bindCallback":380}],356:[function(require,module,exports){
+},{"../utility/identity":439,"../utility/property":440,"./baseMatches":370,"./baseMatchesProperty":371,"./bindCallback":381}],357:[function(require,module,exports){
 var arrayCopy = require('./arrayCopy'),
     arrayEach = require('./arrayEach'),
     baseAssign = require('./baseAssign'),
@@ -47460,7 +47504,7 @@ function baseClone(value, isDeep, customizer, key, object, stackA, stackB) {
 
 module.exports = baseClone;
 
-},{"../lang/isArray":416,"../lang/isObject":421,"./arrayCopy":348,"./arrayEach":349,"./baseAssign":354,"./baseForOwn":362,"./initCloneArray":399,"./initCloneByTag":400,"./initCloneObject":401}],357:[function(require,module,exports){
+},{"../lang/isArray":417,"../lang/isObject":422,"./arrayCopy":349,"./arrayEach":350,"./baseAssign":355,"./baseForOwn":363,"./initCloneArray":400,"./initCloneByTag":401,"./initCloneObject":402}],358:[function(require,module,exports){
 /**
  * The base implementation of `compareAscending` which compares values and
  * sorts them in ascending order without guaranteeing a stable sort.
@@ -47496,7 +47540,7 @@ function baseCompareAscending(value, other) {
 
 module.exports = baseCompareAscending;
 
-},{}],358:[function(require,module,exports){
+},{}],359:[function(require,module,exports){
 /**
  * Copies properties of `source` to `object`.
  *
@@ -47521,7 +47565,7 @@ function baseCopy(source, props, object) {
 
 module.exports = baseCopy;
 
-},{}],359:[function(require,module,exports){
+},{}],360:[function(require,module,exports){
 var baseForOwn = require('./baseForOwn'),
     createBaseEach = require('./createBaseEach');
 
@@ -47538,7 +47582,7 @@ var baseEach = createBaseEach(baseForOwn);
 
 module.exports = baseEach;
 
-},{"./baseForOwn":362,"./createBaseEach":386}],360:[function(require,module,exports){
+},{"./baseForOwn":363,"./createBaseEach":387}],361:[function(require,module,exports){
 var createBaseFor = require('./createBaseFor');
 
 /**
@@ -47557,7 +47601,7 @@ var baseFor = createBaseFor();
 
 module.exports = baseFor;
 
-},{"./createBaseFor":387}],361:[function(require,module,exports){
+},{"./createBaseFor":388}],362:[function(require,module,exports){
 var baseFor = require('./baseFor'),
     keysIn = require('../object/keysIn');
 
@@ -47576,7 +47620,7 @@ function baseForIn(object, iteratee) {
 
 module.exports = baseForIn;
 
-},{"../object/keysIn":432,"./baseFor":360}],362:[function(require,module,exports){
+},{"../object/keysIn":433,"./baseFor":361}],363:[function(require,module,exports){
 var baseFor = require('./baseFor'),
     keys = require('../object/keys');
 
@@ -47595,7 +47639,7 @@ function baseForOwn(object, iteratee) {
 
 module.exports = baseForOwn;
 
-},{"../object/keys":431,"./baseFor":360}],363:[function(require,module,exports){
+},{"../object/keys":432,"./baseFor":361}],364:[function(require,module,exports){
 var toObject = require('./toObject');
 
 /**
@@ -47626,7 +47670,7 @@ function baseGet(object, path, pathKey) {
 
 module.exports = baseGet;
 
-},{"./toObject":411}],364:[function(require,module,exports){
+},{"./toObject":412}],365:[function(require,module,exports){
 var indexOfNaN = require('./indexOfNaN');
 
 /**
@@ -47655,7 +47699,7 @@ function baseIndexOf(array, value, fromIndex) {
 
 module.exports = baseIndexOf;
 
-},{"./indexOfNaN":398}],365:[function(require,module,exports){
+},{"./indexOfNaN":399}],366:[function(require,module,exports){
 var baseIsEqualDeep = require('./baseIsEqualDeep'),
     isObject = require('../lang/isObject'),
     isObjectLike = require('./isObjectLike');
@@ -47685,7 +47729,7 @@ function baseIsEqual(value, other, customizer, isLoose, stackA, stackB) {
 
 module.exports = baseIsEqual;
 
-},{"../lang/isObject":421,"./baseIsEqualDeep":366,"./isObjectLike":407}],366:[function(require,module,exports){
+},{"../lang/isObject":422,"./baseIsEqualDeep":367,"./isObjectLike":408}],367:[function(require,module,exports){
 var equalArrays = require('./equalArrays'),
     equalByTag = require('./equalByTag'),
     equalObjects = require('./equalObjects'),
@@ -47789,7 +47833,7 @@ function baseIsEqualDeep(object, other, equalFunc, customizer, isLoose, stackA, 
 
 module.exports = baseIsEqualDeep;
 
-},{"../lang/isArray":416,"../lang/isTypedArray":425,"./equalArrays":391,"./equalByTag":392,"./equalObjects":393}],367:[function(require,module,exports){
+},{"../lang/isArray":417,"../lang/isTypedArray":426,"./equalArrays":392,"./equalByTag":393,"./equalObjects":394}],368:[function(require,module,exports){
 var baseIsEqual = require('./baseIsEqual'),
     toObject = require('./toObject');
 
@@ -47843,7 +47887,7 @@ function baseIsMatch(object, matchData, customizer) {
 
 module.exports = baseIsMatch;
 
-},{"./baseIsEqual":365,"./toObject":411}],368:[function(require,module,exports){
+},{"./baseIsEqual":366,"./toObject":412}],369:[function(require,module,exports){
 var baseEach = require('./baseEach'),
     isArrayLike = require('./isArrayLike');
 
@@ -47868,7 +47912,7 @@ function baseMap(collection, iteratee) {
 
 module.exports = baseMap;
 
-},{"./baseEach":359,"./isArrayLike":402}],369:[function(require,module,exports){
+},{"./baseEach":360,"./isArrayLike":403}],370:[function(require,module,exports){
 var baseIsMatch = require('./baseIsMatch'),
     getMatchData = require('./getMatchData'),
     toObject = require('./toObject');
@@ -47900,7 +47944,7 @@ function baseMatches(source) {
 
 module.exports = baseMatches;
 
-},{"./baseIsMatch":367,"./getMatchData":396,"./toObject":411}],370:[function(require,module,exports){
+},{"./baseIsMatch":368,"./getMatchData":397,"./toObject":412}],371:[function(require,module,exports){
 var baseGet = require('./baseGet'),
     baseIsEqual = require('./baseIsEqual'),
     baseSlice = require('./baseSlice'),
@@ -47947,7 +47991,7 @@ function baseMatchesProperty(path, srcValue) {
 
 module.exports = baseMatchesProperty;
 
-},{"../array/last":337,"../lang/isArray":416,"./baseGet":363,"./baseIsEqual":365,"./baseSlice":375,"./isKey":405,"./isStrictComparable":408,"./toObject":411,"./toPath":412}],371:[function(require,module,exports){
+},{"../array/last":338,"../lang/isArray":417,"./baseGet":364,"./baseIsEqual":366,"./baseSlice":376,"./isKey":406,"./isStrictComparable":409,"./toObject":412,"./toPath":413}],372:[function(require,module,exports){
 var arrayEach = require('./arrayEach'),
     baseMergeDeep = require('./baseMergeDeep'),
     isArray = require('../lang/isArray'),
@@ -48005,7 +48049,7 @@ function baseMerge(object, source, customizer, stackA, stackB) {
 
 module.exports = baseMerge;
 
-},{"../lang/isArray":416,"../lang/isObject":421,"../lang/isTypedArray":425,"../object/keys":431,"./arrayEach":349,"./baseMergeDeep":372,"./isArrayLike":402,"./isObjectLike":407}],372:[function(require,module,exports){
+},{"../lang/isArray":417,"../lang/isObject":422,"../lang/isTypedArray":426,"../object/keys":432,"./arrayEach":350,"./baseMergeDeep":373,"./isArrayLike":403,"./isObjectLike":408}],373:[function(require,module,exports){
 var arrayCopy = require('./arrayCopy'),
     isArguments = require('../lang/isArguments'),
     isArray = require('../lang/isArray'),
@@ -48074,7 +48118,7 @@ function baseMergeDeep(object, source, key, mergeFunc, customizer, stackA, stack
 
 module.exports = baseMergeDeep;
 
-},{"../lang/isArguments":415,"../lang/isArray":416,"../lang/isPlainObject":422,"../lang/isTypedArray":425,"../lang/toPlainObject":426,"./arrayCopy":348,"./isArrayLike":402}],373:[function(require,module,exports){
+},{"../lang/isArguments":416,"../lang/isArray":417,"../lang/isPlainObject":423,"../lang/isTypedArray":426,"../lang/toPlainObject":427,"./arrayCopy":349,"./isArrayLike":403}],374:[function(require,module,exports){
 /**
  * The base implementation of `_.property` without support for deep paths.
  *
@@ -48090,7 +48134,7 @@ function baseProperty(key) {
 
 module.exports = baseProperty;
 
-},{}],374:[function(require,module,exports){
+},{}],375:[function(require,module,exports){
 var baseGet = require('./baseGet'),
     toPath = require('./toPath');
 
@@ -48111,7 +48155,7 @@ function basePropertyDeep(path) {
 
 module.exports = basePropertyDeep;
 
-},{"./baseGet":363,"./toPath":412}],375:[function(require,module,exports){
+},{"./baseGet":364,"./toPath":413}],376:[function(require,module,exports){
 /**
  * The base implementation of `_.slice` without an iteratee call guard.
  *
@@ -48145,7 +48189,7 @@ function baseSlice(array, start, end) {
 
 module.exports = baseSlice;
 
-},{}],376:[function(require,module,exports){
+},{}],377:[function(require,module,exports){
 /**
  * The base implementation of `_.sortBy` which uses `comparer` to define
  * the sort order of `array` and replaces criteria objects with their
@@ -48168,7 +48212,7 @@ function baseSortBy(array, comparer) {
 
 module.exports = baseSortBy;
 
-},{}],377:[function(require,module,exports){
+},{}],378:[function(require,module,exports){
 /**
  * Converts `value` to a string if it's not one. An empty string is returned
  * for `null` or `undefined` values.
@@ -48183,7 +48227,7 @@ function baseToString(value) {
 
 module.exports = baseToString;
 
-},{}],378:[function(require,module,exports){
+},{}],379:[function(require,module,exports){
 var baseIndexOf = require('./baseIndexOf'),
     cacheIndexOf = require('./cacheIndexOf'),
     createCache = require('./createCache');
@@ -48245,7 +48289,7 @@ function baseUniq(array, iteratee) {
 
 module.exports = baseUniq;
 
-},{"./baseIndexOf":364,"./cacheIndexOf":382,"./createCache":388}],379:[function(require,module,exports){
+},{"./baseIndexOf":365,"./cacheIndexOf":383,"./createCache":389}],380:[function(require,module,exports){
 /**
  * The base implementation of `_.values` and `_.valuesIn` which creates an
  * array of `object` property values corresponding to the property names
@@ -48269,7 +48313,7 @@ function baseValues(object, props) {
 
 module.exports = baseValues;
 
-},{}],380:[function(require,module,exports){
+},{}],381:[function(require,module,exports){
 var identity = require('../utility/identity');
 
 /**
@@ -48310,7 +48354,7 @@ function bindCallback(func, thisArg, argCount) {
 
 module.exports = bindCallback;
 
-},{"../utility/identity":438}],381:[function(require,module,exports){
+},{"../utility/identity":439}],382:[function(require,module,exports){
 (function (global){
 /** Native method references. */
 var ArrayBuffer = global.ArrayBuffer,
@@ -48334,7 +48378,7 @@ function bufferClone(buffer) {
 module.exports = bufferClone;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],382:[function(require,module,exports){
+},{}],383:[function(require,module,exports){
 var isObject = require('../lang/isObject');
 
 /**
@@ -48355,7 +48399,7 @@ function cacheIndexOf(cache, value) {
 
 module.exports = cacheIndexOf;
 
-},{"../lang/isObject":421}],383:[function(require,module,exports){
+},{"../lang/isObject":422}],384:[function(require,module,exports){
 var isObject = require('../lang/isObject');
 
 /**
@@ -48377,7 +48421,7 @@ function cachePush(value) {
 
 module.exports = cachePush;
 
-},{"../lang/isObject":421}],384:[function(require,module,exports){
+},{"../lang/isObject":422}],385:[function(require,module,exports){
 var baseCompareAscending = require('./baseCompareAscending');
 
 /**
@@ -48395,7 +48439,7 @@ function compareAscending(object, other) {
 
 module.exports = compareAscending;
 
-},{"./baseCompareAscending":357}],385:[function(require,module,exports){
+},{"./baseCompareAscending":358}],386:[function(require,module,exports){
 var bindCallback = require('./bindCallback'),
     isIterateeCall = require('./isIterateeCall'),
     restParam = require('../function/restParam');
@@ -48438,7 +48482,7 @@ function createAssigner(assigner) {
 
 module.exports = createAssigner;
 
-},{"../function/restParam":346,"./bindCallback":380,"./isIterateeCall":404}],386:[function(require,module,exports){
+},{"../function/restParam":347,"./bindCallback":381,"./isIterateeCall":405}],387:[function(require,module,exports){
 var getLength = require('./getLength'),
     isLength = require('./isLength'),
     toObject = require('./toObject');
@@ -48471,7 +48515,7 @@ function createBaseEach(eachFunc, fromRight) {
 
 module.exports = createBaseEach;
 
-},{"./getLength":395,"./isLength":406,"./toObject":411}],387:[function(require,module,exports){
+},{"./getLength":396,"./isLength":407,"./toObject":412}],388:[function(require,module,exports){
 var toObject = require('./toObject');
 
 /**
@@ -48500,7 +48544,7 @@ function createBaseFor(fromRight) {
 
 module.exports = createBaseFor;
 
-},{"./toObject":411}],388:[function(require,module,exports){
+},{"./toObject":412}],389:[function(require,module,exports){
 (function (global){
 var SetCache = require('./SetCache'),
     getNative = require('./getNative');
@@ -48525,7 +48569,7 @@ function createCache(values) {
 module.exports = createCache;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./SetCache":347,"./getNative":397}],389:[function(require,module,exports){
+},{"./SetCache":348,"./getNative":398}],390:[function(require,module,exports){
 var restParam = require('../function/restParam');
 
 /**
@@ -48549,7 +48593,7 @@ function createDefaults(assigner, customizer) {
 
 module.exports = createDefaults;
 
-},{"../function/restParam":346}],390:[function(require,module,exports){
+},{"../function/restParam":347}],391:[function(require,module,exports){
 var bindCallback = require('./bindCallback'),
     isArray = require('../lang/isArray');
 
@@ -48571,7 +48615,7 @@ function createForEach(arrayFunc, eachFunc) {
 
 module.exports = createForEach;
 
-},{"../lang/isArray":416,"./bindCallback":380}],391:[function(require,module,exports){
+},{"../lang/isArray":417,"./bindCallback":381}],392:[function(require,module,exports){
 var arraySome = require('./arraySome');
 
 /**
@@ -48624,7 +48668,7 @@ function equalArrays(array, other, equalFunc, customizer, isLoose, stackA, stack
 
 module.exports = equalArrays;
 
-},{"./arraySome":351}],392:[function(require,module,exports){
+},{"./arraySome":352}],393:[function(require,module,exports){
 /** `Object#toString` result references. */
 var boolTag = '[object Boolean]',
     dateTag = '[object Date]',
@@ -48674,7 +48718,7 @@ function equalByTag(object, other, tag) {
 
 module.exports = equalByTag;
 
-},{}],393:[function(require,module,exports){
+},{}],394:[function(require,module,exports){
 var keys = require('../object/keys');
 
 /** Used for native method references. */
@@ -48743,7 +48787,7 @@ function equalObjects(object, other, equalFunc, customizer, isLoose, stackA, sta
 
 module.exports = equalObjects;
 
-},{"../object/keys":431}],394:[function(require,module,exports){
+},{"../object/keys":432}],395:[function(require,module,exports){
 /** Used to escape characters for inclusion in compiled regexes. */
 var regexpEscapes = {
   '0': 'x30', '1': 'x31', '2': 'x32', '3': 'x33', '4': 'x34',
@@ -48783,7 +48827,7 @@ function escapeRegExpChar(chr, leadingChar, whitespaceChar) {
 
 module.exports = escapeRegExpChar;
 
-},{}],395:[function(require,module,exports){
+},{}],396:[function(require,module,exports){
 var baseProperty = require('./baseProperty');
 
 /**
@@ -48800,7 +48844,7 @@ var getLength = baseProperty('length');
 
 module.exports = getLength;
 
-},{"./baseProperty":373}],396:[function(require,module,exports){
+},{"./baseProperty":374}],397:[function(require,module,exports){
 var isStrictComparable = require('./isStrictComparable'),
     pairs = require('../object/pairs');
 
@@ -48823,7 +48867,7 @@ function getMatchData(object) {
 
 module.exports = getMatchData;
 
-},{"../object/pairs":434,"./isStrictComparable":408}],397:[function(require,module,exports){
+},{"../object/pairs":435,"./isStrictComparable":409}],398:[function(require,module,exports){
 var isNative = require('../lang/isNative');
 
 /**
@@ -48841,7 +48885,7 @@ function getNative(object, key) {
 
 module.exports = getNative;
 
-},{"../lang/isNative":419}],398:[function(require,module,exports){
+},{"../lang/isNative":420}],399:[function(require,module,exports){
 /**
  * Gets the index at which the first occurrence of `NaN` is found in `array`.
  *
@@ -48866,7 +48910,7 @@ function indexOfNaN(array, fromIndex, fromRight) {
 
 module.exports = indexOfNaN;
 
-},{}],399:[function(require,module,exports){
+},{}],400:[function(require,module,exports){
 /** Used for native method references. */
 var objectProto = Object.prototype;
 
@@ -48894,7 +48938,7 @@ function initCloneArray(array) {
 
 module.exports = initCloneArray;
 
-},{}],400:[function(require,module,exports){
+},{}],401:[function(require,module,exports){
 var bufferClone = require('./bufferClone');
 
 /** `Object#toString` result references. */
@@ -48959,7 +49003,7 @@ function initCloneByTag(object, tag, isDeep) {
 
 module.exports = initCloneByTag;
 
-},{"./bufferClone":381}],401:[function(require,module,exports){
+},{"./bufferClone":382}],402:[function(require,module,exports){
 /**
  * Initializes an object clone.
  *
@@ -48977,7 +49021,7 @@ function initCloneObject(object) {
 
 module.exports = initCloneObject;
 
-},{}],402:[function(require,module,exports){
+},{}],403:[function(require,module,exports){
 var getLength = require('./getLength'),
     isLength = require('./isLength');
 
@@ -48994,7 +49038,7 @@ function isArrayLike(value) {
 
 module.exports = isArrayLike;
 
-},{"./getLength":395,"./isLength":406}],403:[function(require,module,exports){
+},{"./getLength":396,"./isLength":407}],404:[function(require,module,exports){
 /** Used to detect unsigned integer values. */
 var reIsUint = /^\d+$/;
 
@@ -49020,7 +49064,7 @@ function isIndex(value, length) {
 
 module.exports = isIndex;
 
-},{}],404:[function(require,module,exports){
+},{}],405:[function(require,module,exports){
 var isArrayLike = require('./isArrayLike'),
     isIndex = require('./isIndex'),
     isObject = require('../lang/isObject');
@@ -49050,7 +49094,7 @@ function isIterateeCall(value, index, object) {
 
 module.exports = isIterateeCall;
 
-},{"../lang/isObject":421,"./isArrayLike":402,"./isIndex":403}],405:[function(require,module,exports){
+},{"../lang/isObject":422,"./isArrayLike":403,"./isIndex":404}],406:[function(require,module,exports){
 var isArray = require('../lang/isArray'),
     toObject = require('./toObject');
 
@@ -49080,7 +49124,7 @@ function isKey(value, object) {
 
 module.exports = isKey;
 
-},{"../lang/isArray":416,"./toObject":411}],406:[function(require,module,exports){
+},{"../lang/isArray":417,"./toObject":412}],407:[function(require,module,exports){
 /**
  * Used as the [maximum length](http://ecma-international.org/ecma-262/6.0/#sec-number.max_safe_integer)
  * of an array-like value.
@@ -49102,7 +49146,7 @@ function isLength(value) {
 
 module.exports = isLength;
 
-},{}],407:[function(require,module,exports){
+},{}],408:[function(require,module,exports){
 /**
  * Checks if `value` is object-like.
  *
@@ -49116,7 +49160,7 @@ function isObjectLike(value) {
 
 module.exports = isObjectLike;
 
-},{}],408:[function(require,module,exports){
+},{}],409:[function(require,module,exports){
 var isObject = require('../lang/isObject');
 
 /**
@@ -49133,7 +49177,7 @@ function isStrictComparable(value) {
 
 module.exports = isStrictComparable;
 
-},{"../lang/isObject":421}],409:[function(require,module,exports){
+},{"../lang/isObject":422}],410:[function(require,module,exports){
 var isArguments = require('../lang/isArguments'),
     isArray = require('../lang/isArray'),
     isIndex = require('./isIndex'),
@@ -49176,7 +49220,7 @@ function shimKeys(object) {
 
 module.exports = shimKeys;
 
-},{"../lang/isArguments":415,"../lang/isArray":416,"../object/keysIn":432,"./isIndex":403,"./isLength":406}],410:[function(require,module,exports){
+},{"../lang/isArguments":416,"../lang/isArray":417,"../object/keysIn":433,"./isIndex":404,"./isLength":407}],411:[function(require,module,exports){
 /**
  * An implementation of `_.uniq` optimized for sorted arrays without support
  * for callback shorthands and `this` binding.
@@ -49207,7 +49251,7 @@ function sortedUniq(array, iteratee) {
 
 module.exports = sortedUniq;
 
-},{}],411:[function(require,module,exports){
+},{}],412:[function(require,module,exports){
 var isObject = require('../lang/isObject');
 
 /**
@@ -49223,7 +49267,7 @@ function toObject(value) {
 
 module.exports = toObject;
 
-},{"../lang/isObject":421}],412:[function(require,module,exports){
+},{"../lang/isObject":422}],413:[function(require,module,exports){
 var baseToString = require('./baseToString'),
     isArray = require('../lang/isArray');
 
@@ -49253,7 +49297,7 @@ function toPath(value) {
 
 module.exports = toPath;
 
-},{"../lang/isArray":416,"./baseToString":377}],413:[function(require,module,exports){
+},{"../lang/isArray":417,"./baseToString":378}],414:[function(require,module,exports){
 var baseClone = require('../internal/baseClone'),
     bindCallback = require('../internal/bindCallback'),
     isIterateeCall = require('../internal/isIterateeCall');
@@ -49325,7 +49369,7 @@ function clone(value, isDeep, customizer, thisArg) {
 
 module.exports = clone;
 
-},{"../internal/baseClone":356,"../internal/bindCallback":380,"../internal/isIterateeCall":404}],414:[function(require,module,exports){
+},{"../internal/baseClone":357,"../internal/bindCallback":381,"../internal/isIterateeCall":405}],415:[function(require,module,exports){
 var baseClone = require('../internal/baseClone'),
     bindCallback = require('../internal/bindCallback');
 
@@ -49382,7 +49426,7 @@ function cloneDeep(value, customizer, thisArg) {
 
 module.exports = cloneDeep;
 
-},{"../internal/baseClone":356,"../internal/bindCallback":380}],415:[function(require,module,exports){
+},{"../internal/baseClone":357,"../internal/bindCallback":381}],416:[function(require,module,exports){
 var isArrayLike = require('../internal/isArrayLike'),
     isObjectLike = require('../internal/isObjectLike');
 
@@ -49418,7 +49462,7 @@ function isArguments(value) {
 
 module.exports = isArguments;
 
-},{"../internal/isArrayLike":402,"../internal/isObjectLike":407}],416:[function(require,module,exports){
+},{"../internal/isArrayLike":403,"../internal/isObjectLike":408}],417:[function(require,module,exports){
 var getNative = require('../internal/getNative'),
     isLength = require('../internal/isLength'),
     isObjectLike = require('../internal/isObjectLike');
@@ -49460,7 +49504,7 @@ var isArray = nativeIsArray || function(value) {
 
 module.exports = isArray;
 
-},{"../internal/getNative":397,"../internal/isLength":406,"../internal/isObjectLike":407}],417:[function(require,module,exports){
+},{"../internal/getNative":398,"../internal/isLength":407,"../internal/isObjectLike":408}],418:[function(require,module,exports){
 var isObjectLike = require('../internal/isObjectLike');
 
 /** `Object#toString` result references. */
@@ -49497,7 +49541,7 @@ function isBoolean(value) {
 
 module.exports = isBoolean;
 
-},{"../internal/isObjectLike":407}],418:[function(require,module,exports){
+},{"../internal/isObjectLike":408}],419:[function(require,module,exports){
 var isObject = require('./isObject');
 
 /** `Object#toString` result references. */
@@ -49537,7 +49581,7 @@ function isFunction(value) {
 
 module.exports = isFunction;
 
-},{"./isObject":421}],419:[function(require,module,exports){
+},{"./isObject":422}],420:[function(require,module,exports){
 var isFunction = require('./isFunction'),
     isObjectLike = require('../internal/isObjectLike');
 
@@ -49587,7 +49631,7 @@ function isNative(value) {
 
 module.exports = isNative;
 
-},{"../internal/isObjectLike":407,"./isFunction":418}],420:[function(require,module,exports){
+},{"../internal/isObjectLike":408,"./isFunction":419}],421:[function(require,module,exports){
 var isObjectLike = require('../internal/isObjectLike');
 
 /** `Object#toString` result references. */
@@ -49630,7 +49674,7 @@ function isNumber(value) {
 
 module.exports = isNumber;
 
-},{"../internal/isObjectLike":407}],421:[function(require,module,exports){
+},{"../internal/isObjectLike":408}],422:[function(require,module,exports){
 /**
  * Checks if `value` is the [language type](https://es5.github.io/#x8) of `Object`.
  * (e.g. arrays, functions, objects, regexes, `new Number(0)`, and `new String('')`)
@@ -49660,7 +49704,7 @@ function isObject(value) {
 
 module.exports = isObject;
 
-},{}],422:[function(require,module,exports){
+},{}],423:[function(require,module,exports){
 var baseForIn = require('../internal/baseForIn'),
     isArguments = require('./isArguments'),
     isObjectLike = require('../internal/isObjectLike');
@@ -49733,7 +49777,7 @@ function isPlainObject(value) {
 
 module.exports = isPlainObject;
 
-},{"../internal/baseForIn":361,"../internal/isObjectLike":407,"./isArguments":415}],423:[function(require,module,exports){
+},{"../internal/baseForIn":362,"../internal/isObjectLike":408,"./isArguments":416}],424:[function(require,module,exports){
 var isObject = require('./isObject');
 
 /** `Object#toString` result references. */
@@ -49770,7 +49814,7 @@ function isRegExp(value) {
 
 module.exports = isRegExp;
 
-},{"./isObject":421}],424:[function(require,module,exports){
+},{"./isObject":422}],425:[function(require,module,exports){
 var isObjectLike = require('../internal/isObjectLike');
 
 /** `Object#toString` result references. */
@@ -49807,7 +49851,7 @@ function isString(value) {
 
 module.exports = isString;
 
-},{"../internal/isObjectLike":407}],425:[function(require,module,exports){
+},{"../internal/isObjectLike":408}],426:[function(require,module,exports){
 var isLength = require('../internal/isLength'),
     isObjectLike = require('../internal/isObjectLike');
 
@@ -49883,7 +49927,7 @@ function isTypedArray(value) {
 
 module.exports = isTypedArray;
 
-},{"../internal/isLength":406,"../internal/isObjectLike":407}],426:[function(require,module,exports){
+},{"../internal/isLength":407,"../internal/isObjectLike":408}],427:[function(require,module,exports){
 var baseCopy = require('../internal/baseCopy'),
     keysIn = require('../object/keysIn');
 
@@ -49916,7 +49960,7 @@ function toPlainObject(value) {
 
 module.exports = toPlainObject;
 
-},{"../internal/baseCopy":358,"../object/keysIn":432}],427:[function(require,module,exports){
+},{"../internal/baseCopy":359,"../object/keysIn":433}],428:[function(require,module,exports){
 var assignWith = require('../internal/assignWith'),
     baseAssign = require('../internal/baseAssign'),
     createAssigner = require('../internal/createAssigner');
@@ -49961,7 +50005,7 @@ var assign = createAssigner(function(object, source, customizer) {
 
 module.exports = assign;
 
-},{"../internal/assignWith":353,"../internal/baseAssign":354,"../internal/createAssigner":385}],428:[function(require,module,exports){
+},{"../internal/assignWith":354,"../internal/baseAssign":355,"../internal/createAssigner":386}],429:[function(require,module,exports){
 var assign = require('./assign'),
     assignDefaults = require('../internal/assignDefaults'),
     createDefaults = require('../internal/createDefaults');
@@ -49988,10 +50032,10 @@ var defaults = createDefaults(assign, assignDefaults);
 
 module.exports = defaults;
 
-},{"../internal/assignDefaults":352,"../internal/createDefaults":389,"./assign":427}],429:[function(require,module,exports){
+},{"../internal/assignDefaults":353,"../internal/createDefaults":390,"./assign":428}],430:[function(require,module,exports){
 module.exports = require('./assign');
 
-},{"./assign":427}],430:[function(require,module,exports){
+},{"./assign":428}],431:[function(require,module,exports){
 var baseGet = require('../internal/baseGet'),
     baseSlice = require('../internal/baseSlice'),
     isArguments = require('../lang/isArguments'),
@@ -50050,7 +50094,7 @@ function has(object, path) {
 
 module.exports = has;
 
-},{"../array/last":337,"../internal/baseGet":363,"../internal/baseSlice":375,"../internal/isIndex":403,"../internal/isKey":405,"../internal/isLength":406,"../internal/toPath":412,"../lang/isArguments":415,"../lang/isArray":416}],431:[function(require,module,exports){
+},{"../array/last":338,"../internal/baseGet":364,"../internal/baseSlice":376,"../internal/isIndex":404,"../internal/isKey":406,"../internal/isLength":407,"../internal/toPath":413,"../lang/isArguments":416,"../lang/isArray":417}],432:[function(require,module,exports){
 var getNative = require('../internal/getNative'),
     isArrayLike = require('../internal/isArrayLike'),
     isObject = require('../lang/isObject'),
@@ -50097,7 +50141,7 @@ var keys = !nativeKeys ? shimKeys : function(object) {
 
 module.exports = keys;
 
-},{"../internal/getNative":397,"../internal/isArrayLike":402,"../internal/shimKeys":409,"../lang/isObject":421}],432:[function(require,module,exports){
+},{"../internal/getNative":398,"../internal/isArrayLike":403,"../internal/shimKeys":410,"../lang/isObject":422}],433:[function(require,module,exports){
 var isArguments = require('../lang/isArguments'),
     isArray = require('../lang/isArray'),
     isIndex = require('../internal/isIndex'),
@@ -50163,7 +50207,7 @@ function keysIn(object) {
 
 module.exports = keysIn;
 
-},{"../internal/isIndex":403,"../internal/isLength":406,"../lang/isArguments":415,"../lang/isArray":416,"../lang/isObject":421}],433:[function(require,module,exports){
+},{"../internal/isIndex":404,"../internal/isLength":407,"../lang/isArguments":416,"../lang/isArray":417,"../lang/isObject":422}],434:[function(require,module,exports){
 var baseMerge = require('../internal/baseMerge'),
     createAssigner = require('../internal/createAssigner');
 
@@ -50219,7 +50263,7 @@ var merge = createAssigner(baseMerge);
 
 module.exports = merge;
 
-},{"../internal/baseMerge":371,"../internal/createAssigner":385}],434:[function(require,module,exports){
+},{"../internal/baseMerge":372,"../internal/createAssigner":386}],435:[function(require,module,exports){
 var keys = require('./keys'),
     toObject = require('../internal/toObject');
 
@@ -50254,7 +50298,7 @@ function pairs(object) {
 
 module.exports = pairs;
 
-},{"../internal/toObject":411,"./keys":431}],435:[function(require,module,exports){
+},{"../internal/toObject":412,"./keys":432}],436:[function(require,module,exports){
 var baseValues = require('../internal/baseValues'),
     keys = require('./keys');
 
@@ -50289,7 +50333,7 @@ function values(object) {
 
 module.exports = values;
 
-},{"../internal/baseValues":379,"./keys":431}],436:[function(require,module,exports){
+},{"../internal/baseValues":380,"./keys":432}],437:[function(require,module,exports){
 var baseToString = require('../internal/baseToString'),
     escapeRegExpChar = require('../internal/escapeRegExpChar');
 
@@ -50323,7 +50367,7 @@ function escapeRegExp(string) {
 
 module.exports = escapeRegExp;
 
-},{"../internal/baseToString":377,"../internal/escapeRegExpChar":394}],437:[function(require,module,exports){
+},{"../internal/baseToString":378,"../internal/escapeRegExpChar":395}],438:[function(require,module,exports){
 var baseToString = require('../internal/baseToString');
 
 /* Native method references for those with the same name as other `lodash` methods. */
@@ -50361,7 +50405,7 @@ function startsWith(string, target, position) {
 
 module.exports = startsWith;
 
-},{"../internal/baseToString":377}],438:[function(require,module,exports){
+},{"../internal/baseToString":378}],439:[function(require,module,exports){
 /**
  * This method returns the first argument provided to it.
  *
@@ -50383,7 +50427,7 @@ function identity(value) {
 
 module.exports = identity;
 
-},{}],439:[function(require,module,exports){
+},{}],440:[function(require,module,exports){
 var baseProperty = require('../internal/baseProperty'),
     basePropertyDeep = require('../internal/basePropertyDeep'),
     isKey = require('../internal/isKey');
@@ -50416,7 +50460,7 @@ function property(path) {
 
 module.exports = property;
 
-},{"../internal/baseProperty":373,"../internal/basePropertyDeep":374,"../internal/isKey":405}],440:[function(require,module,exports){
+},{"../internal/baseProperty":374,"../internal/basePropertyDeep":375,"../internal/isKey":406}],441:[function(require,module,exports){
 module.exports = minimatch
 minimatch.Minimatch = Minimatch
 
@@ -51330,7 +51374,7 @@ function regExpEscape (s) {
   return s.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
 }
 
-},{"brace-expansion":227,"path":443}],441:[function(require,module,exports){
+},{"brace-expansion":228,"path":444}],442:[function(require,module,exports){
 /**
  * Helpers.
  */
@@ -51457,13 +51501,13 @@ function plural(ms, n, name) {
   return Math.ceil(ms / n) + ' ' + name + 's';
 }
 
-},{}],442:[function(require,module,exports){
+},{}],443:[function(require,module,exports){
 'use strict';
 module.exports = Number.isNaN || function (x) {
 	return x !== x;
 };
 
-},{}],443:[function(require,module,exports){
+},{}],444:[function(require,module,exports){
 (function (process){
 // Copyright Joyent, Inc. and other Node contributors.
 //
@@ -51691,7 +51735,7 @@ var substr = 'ab'.substr(-1) === 'b'
 ;
 
 }).call(this,require('_process'))
-},{"_process":448}],444:[function(require,module,exports){
+},{"_process":449}],445:[function(require,module,exports){
 'use strict';
 var fs = require('fs')
 
@@ -51714,7 +51758,7 @@ module.exports.sync = function (pth) {
 	}
 };
 
-},{"fs":228}],445:[function(require,module,exports){
+},{"fs":229}],446:[function(require,module,exports){
 (function (process){
 'use strict';
 
@@ -51738,7 +51782,7 @@ module.exports.posix = posix;
 module.exports.win32 = win32;
 
 }).call(this,require('_process'))
-},{"_process":448}],446:[function(require,module,exports){
+},{"_process":449}],447:[function(require,module,exports){
 /**
  * JavaScript beautifier
  *
@@ -53264,7 +53308,7 @@ module.exports.win32 = win32;
 }));
 // fid-umd post-end
 
-},{"complexion":233,"complexion-js":232}],447:[function(require,module,exports){
+},{"complexion":234,"complexion-js":233}],448:[function(require,module,exports){
 "use strict";
 
 var originalObject = Object;
@@ -53395,7 +53439,7 @@ function makeAccessor(secretCreatorFn) {
 
 defProp(exports, "makeAccessor", makeAccessor);
 
-},{}],448:[function(require,module,exports){
+},{}],449:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 
@@ -53577,7 +53621,7 @@ process.chdir = function (dir) {
 };
 process.umask = function() { return 0; };
 
-},{}],449:[function(require,module,exports){
+},{}],450:[function(require,module,exports){
 'use strict';
 var strictUriEncode = require('strict-uri-encode');
 
@@ -53635,7 +53679,7 @@ exports.stringify = function (obj) {
 	}).join('&') : '';
 };
 
-},{"strict-uri-encode":485}],450:[function(require,module,exports){
+},{"strict-uri-encode":486}],451:[function(require,module,exports){
 module.exports = {
     Either: require('./src/Either'),
     Future: require('./src/Future'),
@@ -53648,7 +53692,7 @@ module.exports = {
     Reader: require('./src/Reader')
 };
 
-},{"./src/Either":452,"./src/Future":453,"./src/IO":454,"./src/Identity":455,"./src/Maybe":456,"./src/Reader":457,"./src/Tuple":458,"./src/lift2":460,"./src/lift3":461}],451:[function(require,module,exports){
+},{"./src/Either":453,"./src/Future":454,"./src/IO":455,"./src/Identity":456,"./src/Maybe":457,"./src/Reader":458,"./src/Tuple":459,"./src/lift2":461,"./src/lift3":462}],452:[function(require,module,exports){
 //  Ramda v0.17.1
 //  https://github.com/ramda/ramda
 //  (c) 2013-2015 Scott Sauyet, Michael Hurley, and David Chambers
@@ -61130,7 +61174,7 @@ module.exports = {
 
 }.call(this));
 
-},{}],452:[function(require,module,exports){
+},{}],453:[function(require,module,exports){
 var R = require('ramda');
 
 var util = require('./internal/util');
@@ -61220,7 +61264,7 @@ Either.Left = function(value) {
 
 module.exports = Either;
 
-},{"./internal/util":459,"ramda":451}],453:[function(require,module,exports){
+},{"./internal/util":460,"ramda":452}],454:[function(require,module,exports){
 var R = require('ramda');
 
 // `f` is a function that takes two function arguments: `reject` (failure) and `resolve` (success)
@@ -61368,7 +61412,7 @@ Future.memoize = function(f) {
 
 module.exports = Future;
 
-},{"ramda":451}],454:[function(require,module,exports){
+},{"ramda":452}],455:[function(require,module,exports){
 var R = require('ramda');
 
 module.exports = IO;
@@ -61422,7 +61466,7 @@ IO.prototype.toString = function() {
   return 'IO(' + R.toString(this.fn) + ')';
 };
 
-},{"ramda":451}],455:[function(require,module,exports){
+},{"ramda":452}],456:[function(require,module,exports){
 var R = require('ramda');
 
 var util = require('./internal/util');
@@ -61510,7 +61554,7 @@ Identity.prototype.toString = function() {
 
 module.exports = Identity;
 
-},{"./internal/util":459,"ramda":451}],456:[function(require,module,exports){
+},{"./internal/util":460,"ramda":452}],457:[function(require,module,exports){
 var R = require('ramda');
 
 var util = require('./internal/util.js');
@@ -61634,7 +61678,7 @@ _Nothing.prototype.toString = function() {
 
 module.exports = Maybe;
 
-},{"./internal/util.js":459,"ramda":451}],457:[function(require,module,exports){
+},{"./internal/util.js":460,"ramda":452}],458:[function(require,module,exports){
 var R = require('ramda');
 
 
@@ -61737,7 +61781,7 @@ Reader.T = function(M) {
 
 module.exports = Reader;
 
-},{"ramda":451}],458:[function(require,module,exports){
+},{"ramda":452}],459:[function(require,module,exports){
 var R = require('ramda');
 
 
@@ -61804,7 +61848,7 @@ _Tuple.prototype.toString = function() {
 
 module.exports = Tuple;
 
-},{"ramda":451}],459:[function(require,module,exports){
+},{"ramda":452}],460:[function(require,module,exports){
 var _equals = require('ramda').equals;
 
 
@@ -61847,21 +61891,21 @@ module.exports = {
 
 };
 
-},{"ramda":451}],460:[function(require,module,exports){
+},{"ramda":452}],461:[function(require,module,exports){
 var R = require('ramda');
 
 module.exports = R.curryN(3, function lift2(f, a1, a2) {
   return a1.map(f).ap(a2);
 });
 
-},{"ramda":451}],461:[function(require,module,exports){
+},{"ramda":452}],462:[function(require,module,exports){
 var R = require('ramda');
 
 module.exports = R.curryN(4, function lift3(f, a1, a2, a3) {
   return a1.map(f).ap(a2).ap(a3);
 });
 
-},{"ramda":451}],462:[function(require,module,exports){
+},{"ramda":452}],463:[function(require,module,exports){
 //  Ramda v0.19.0
 //  https://github.com/ramda/ramda
 //  (c) 2013-2015 Scott Sauyet, Michael Hurley, and David Chambers
@@ -70285,7 +70329,7 @@ module.exports = R.curryN(4, function lift3(f, a1, a2, a3) {
 
 }.call(this));
 
-},{}],463:[function(require,module,exports){
+},{}],464:[function(require,module,exports){
 (function (global){
 /*! https://mths.be/regenerate v1.2.0 by @mathias | MIT license */
 ;(function(root) {
@@ -71447,7 +71491,7 @@ module.exports = R.curryN(4, function lift3(f, a1, a2, a3) {
 }(this));
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],464:[function(require,module,exports){
+},{}],465:[function(require,module,exports){
 // Generated by `/scripts/character-class-escape-sets.js`. Do not edit.
 var regenerate = require('regenerate');
 
@@ -71553,7 +71597,7 @@ exports.UNICODE_IGNORE_CASE = {
 		.addRange(0x7B, 0x10FFFF)
 };
 
-},{"regenerate":463}],465:[function(require,module,exports){
+},{"regenerate":464}],466:[function(require,module,exports){
 module.exports={
 	"75": 8490,
 	"83": 383,
@@ -71851,7 +71895,7 @@ module.exports={
 	"71903": 71871
 }
 
-},{}],466:[function(require,module,exports){
+},{}],467:[function(require,module,exports){
 var generate = require('regjsgen').generate;
 var parse = require('regjsparser').parse;
 var regenerate = require('regenerate');
@@ -72046,7 +72090,7 @@ module.exports = function(pattern, flags) {
 	return generate(tree);
 };
 
-},{"./data/character-class-escape-sets.js":464,"./data/iu-mappings.json":465,"regenerate":463,"regjsgen":467,"regjsparser":468}],467:[function(require,module,exports){
+},{"./data/character-class-escape-sets.js":465,"./data/iu-mappings.json":466,"regenerate":464,"regjsgen":468,"regjsparser":469}],468:[function(require,module,exports){
 (function (global){
 /*!
  * RegJSGen
@@ -72458,7 +72502,7 @@ module.exports = function(pattern, flags) {
 }.call(this));
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],468:[function(require,module,exports){
+},{}],469:[function(require,module,exports){
 // regjsparser
 //
 // ==================================================================
@@ -73422,7 +73466,7 @@ module.exports = function(pattern, flags) {
 
 }());
 
-},{}],469:[function(require,module,exports){
+},{}],470:[function(require,module,exports){
 'use strict';
 var isFinite = require('is-finite');
 
@@ -73448,7 +73492,7 @@ module.exports = function (str, n) {
 	return ret;
 };
 
-},{"is-finite":330}],470:[function(require,module,exports){
+},{"is-finite":331}],471:[function(require,module,exports){
 /*    #######
    ####     ####
  ####   ###   ####
@@ -75336,13 +75380,13 @@ module.exports = function (str, n) {
 //. [parseInt]:     https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt
 //. [primitives]:   https://developer.mozilla.org/en-US/docs/Glossary/Primitive
 
-},{"ramda":471}],471:[function(require,module,exports){
-arguments[4][451][0].apply(exports,arguments)
-},{"dup":451}],472:[function(require,module,exports){
+},{"ramda":472}],472:[function(require,module,exports){
+arguments[4][452][0].apply(exports,arguments)
+},{"dup":452}],473:[function(require,module,exports){
 'use strict';
 module.exports = /^#!.*/;
 
-},{}],473:[function(require,module,exports){
+},{}],474:[function(require,module,exports){
 'use strict';
 module.exports = function (str) {
 	var isExtendedLengthPath = /^\\\\\?\\/.test(str);
@@ -75355,7 +75399,7 @@ module.exports = function (str) {
 	return str.replace(/\\/g, '/');
 };
 
-},{}],474:[function(require,module,exports){
+},{}],475:[function(require,module,exports){
 /* -*- Mode: js; js-indent-level: 2; -*- */
 /*
  * Copyright 2011 Mozilla Foundation and contributors
@@ -75461,7 +75505,7 @@ module.exports = function (str) {
   exports.ArraySet = ArraySet;
 }
 
-},{"./util":483}],475:[function(require,module,exports){
+},{"./util":484}],476:[function(require,module,exports){
 /* -*- Mode: js; js-indent-level: 2; -*- */
 /*
  * Copyright 2011 Mozilla Foundation and contributors
@@ -75604,7 +75648,7 @@ module.exports = function (str) {
   };
 }
 
-},{"./base64":476}],476:[function(require,module,exports){
+},{"./base64":477}],477:[function(require,module,exports){
 /* -*- Mode: js; js-indent-level: 2; -*- */
 /*
  * Copyright 2011 Mozilla Foundation and contributors
@@ -75674,7 +75718,7 @@ module.exports = function (str) {
   };
 }
 
-},{}],477:[function(require,module,exports){
+},{}],478:[function(require,module,exports){
 /* -*- Mode: js; js-indent-level: 2; -*- */
 /*
  * Copyright 2011 Mozilla Foundation and contributors
@@ -75788,7 +75832,7 @@ module.exports = function (str) {
   };
 }
 
-},{}],478:[function(require,module,exports){
+},{}],479:[function(require,module,exports){
 /* -*- Mode: js; js-indent-level: 2; -*- */
 /*
  * Copyright 2014 Mozilla Foundation and contributors
@@ -75870,7 +75914,7 @@ module.exports = function (str) {
   exports.MappingList = MappingList;
 }
 
-},{"./util":483}],479:[function(require,module,exports){
+},{"./util":484}],480:[function(require,module,exports){
 /* -*- Mode: js; js-indent-level: 2; -*- */
 /*
  * Copyright 2011 Mozilla Foundation and contributors
@@ -75987,7 +76031,7 @@ module.exports = function (str) {
   };
 }
 
-},{}],480:[function(require,module,exports){
+},{}],481:[function(require,module,exports){
 /* -*- Mode: js; js-indent-level: 2; -*- */
 /*
  * Copyright 2011 Mozilla Foundation and contributors
@@ -77071,7 +77115,7 @@ module.exports = function (str) {
   exports.IndexedSourceMapConsumer = IndexedSourceMapConsumer;
 }
 
-},{"./array-set":474,"./base64-vlq":475,"./binary-search":477,"./quick-sort":479,"./util":483}],481:[function(require,module,exports){
+},{"./array-set":475,"./base64-vlq":476,"./binary-search":478,"./quick-sort":480,"./util":484}],482:[function(require,module,exports){
 /* -*- Mode: js; js-indent-level: 2; -*- */
 /*
  * Copyright 2011 Mozilla Foundation and contributors
@@ -77469,7 +77513,7 @@ module.exports = function (str) {
   exports.SourceMapGenerator = SourceMapGenerator;
 }
 
-},{"./array-set":474,"./base64-vlq":475,"./mapping-list":478,"./util":483}],482:[function(require,module,exports){
+},{"./array-set":475,"./base64-vlq":476,"./mapping-list":479,"./util":484}],483:[function(require,module,exports){
 /* -*- Mode: js; js-indent-level: 2; -*- */
 /*
  * Copyright 2011 Mozilla Foundation and contributors
@@ -77879,7 +77923,7 @@ module.exports = function (str) {
   exports.SourceNode = SourceNode;
 }
 
-},{"./source-map-generator":481,"./util":483}],483:[function(require,module,exports){
+},{"./source-map-generator":482,"./util":484}],484:[function(require,module,exports){
 /* -*- Mode: js; js-indent-level: 2; -*- */
 /*
  * Copyright 2011 Mozilla Foundation and contributors
@@ -78250,7 +78294,7 @@ module.exports = function (str) {
   exports.compareByGeneratedPositionsInflated = compareByGeneratedPositionsInflated;
 }
 
-},{}],484:[function(require,module,exports){
+},{}],485:[function(require,module,exports){
 /*
  * Copyright 2009-2011 Mozilla Foundation and contributors
  * Licensed under the New BSD license. See LICENSE.txt or:
@@ -78260,7 +78304,7 @@ exports.SourceMapGenerator = require('./lib/source-map-generator').SourceMapGene
 exports.SourceMapConsumer = require('./lib/source-map-consumer').SourceMapConsumer;
 exports.SourceNode = require('./lib/source-node').SourceNode;
 
-},{"./lib/source-map-consumer":480,"./lib/source-map-generator":481,"./lib/source-node":482}],485:[function(require,module,exports){
+},{"./lib/source-map-consumer":481,"./lib/source-map-generator":482,"./lib/source-node":483}],486:[function(require,module,exports){
 'use strict';
 module.exports = function (str) {
 	return encodeURIComponent(str).replace(/[!'()*]/g, function (c) {
@@ -78268,7 +78312,7 @@ module.exports = function (str) {
 	});
 };
 
-},{}],486:[function(require,module,exports){
+},{}],487:[function(require,module,exports){
 'use strict';
 var ansiRegex = require('ansi-regex')();
 
@@ -78276,7 +78320,7 @@ module.exports = function (str) {
 	return typeof str === 'string' ? str.replace(ansiRegex, '') : str;
 };
 
-},{"ansi-regex":7}],487:[function(require,module,exports){
+},{"ansi-regex":8}],488:[function(require,module,exports){
 (function (process){
 'use strict';
 var argv = process.argv;
@@ -78330,7 +78374,7 @@ module.exports = (function () {
 })();
 
 }).call(this,require('_process'))
-},{"_process":448}],488:[function(require,module,exports){
+},{"_process":449}],489:[function(require,module,exports){
 'use strict';
 module.exports = function toFastProperties(obj) {
 	/*jshint -W027*/
@@ -78341,7 +78385,7 @@ module.exports = function toFastProperties(obj) {
 	eval(obj);
 };
 
-},{}],489:[function(require,module,exports){
+},{}],490:[function(require,module,exports){
 'use strict';
 module.exports = function (str) {
 	var tail = str.length;
@@ -78353,7 +78397,7 @@ module.exports = function (str) {
 	return str.slice(0, tail);
 };
 
-},{}],490:[function(require,module,exports){
+},{}],491:[function(require,module,exports){
 exports.isatty = function () { return false; };
 
 function ReadStream() {
@@ -78366,14 +78410,14 @@ function WriteStream() {
 }
 exports.WriteStream = WriteStream;
 
-},{}],491:[function(require,module,exports){
+},{}],492:[function(require,module,exports){
 module.exports = function isBuffer(arg) {
   return arg && typeof arg === 'object'
     && typeof arg.copy === 'function'
     && typeof arg.fill === 'function'
     && typeof arg.readUInt8 === 'function';
 }
-},{}],492:[function(require,module,exports){
+},{}],493:[function(require,module,exports){
 (function (process,global){
 // Copyright Joyent, Inc. and other Node contributors.
 //
@@ -78963,4 +79007,4 @@ function hasOwnProperty(obj, prop) {
 }
 
 }).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./support/isBuffer":491,"_process":448,"inherits":328}]},{},[3,5]);
+},{"./support/isBuffer":492,"_process":449,"inherits":329}]},{},[4,6]);

--- a/lib/js/clear.js
+++ b/lib/js/clear.js
@@ -1,0 +1,9 @@
+export default function bindClearButton(options) {
+
+  options.btnClear.addEventListener('click', () => {
+    console.clear();
+    options.output.setValue('');
+    options.evalError.textContent = '';
+  });
+
+}

--- a/lib/js/googl.js
+++ b/lib/js/googl.js
@@ -10,7 +10,6 @@ const req = {
 };
 
 const setValue = R.curry(function(urlOut, data) {
-  console.log('setValue', data);
   urlOut.value = data;
   urlOut.select();
 });
@@ -32,7 +31,7 @@ const xhr = function(url) {
 };
 
 const getResponse = R.compose(R.map(S.parseJson),
-                            R.map(R.path(['target', 'response'])), xhr);
+                            R.map(R.path(['target', 'responseText'])), xhr);
 
 const getShortUrl = urlOut => R.map(R.compose(setValue(urlOut), R.prop('id')));
 

--- a/lib/js/googl.js
+++ b/lib/js/googl.js
@@ -9,16 +9,13 @@ const req = {
   longUrl: 'http://ramdajs.com/repl/'
 };
 
-const makeShortUrlBtn = document.getElementById('mkurl');
-
-const input = document.getElementById('urlout');
-
-const setValue = R.curry(function(data) {
-  input.value = data;
-  input.select();
+const setValue = R.curry(function(urlOut, data) {
+  console.log('setValue', data);
+  urlOut.value = data;
+  urlOut.select();
 });
 
-const error = console.error.bind(console);
+const error = consoleRef => err => consoleRef.error(err);
 
 const xhr = function(url) {
   return new Future(function(reject, resolve) {
@@ -37,8 +34,14 @@ const xhr = function(url) {
 const getResponse = R.compose(R.map(S.parseJson),
                             R.map(R.path(['target', 'response'])), xhr);
 
-const getShortUrl = R.map(R.compose(setValue, R.prop('id')));
+const getShortUrl = urlOut => R.map(R.compose(setValue(urlOut), R.prop('id')));
 
 const futureXhr = getResponse(apiUrl);
 
-export default () => makeShortUrlBtn.addEventListener('click', () => futureXhr.fork(error, getShortUrl));
+export default function bindShortUrlButton(options) {
+
+  options.btnMakeShortUrl.addEventListener('click', function() {
+    futureXhr.fork(error(options.consoleRef), getShortUrl(options.urlOut));
+  });
+
+}

--- a/lib/js/googl.js
+++ b/lib/js/googl.js
@@ -14,7 +14,7 @@ const setValue = R.curry(function(urlOut, data) {
   urlOut.select();
 });
 
-const error = consoleRef => err => consoleRef.error(err);
+const error = err => console.error(err);
 
 const xhr = function(url) {
   return new Future(function(reject, resolve) {
@@ -40,7 +40,7 @@ const futureXhr = getResponse(apiUrl);
 export default function bindShortUrlButton(options) {
 
   options.btnMakeShortUrl.addEventListener('click', function() {
-    futureXhr.fork(error(options.consoleRef), getShortUrl(options.urlOut));
+    futureXhr.fork(error, getShortUrl(options.urlOut));
   });
 
 }

--- a/lib/js/logger.js
+++ b/lib/js/logger.js
@@ -1,7 +1,10 @@
-const consoleLogElement = document.querySelector('.console-log');
+import R from 'ramda';
+
 const internals = {};
 const reporter = {};
 
+let consoleLogElement,
+  consoleRef;
 
 internals.buffer = [];
 
@@ -18,28 +21,31 @@ internals.prepLogs = R.cond([
 ]);
 
 internals.intercept = function(method) {
-  const original = console[method];
-  console[method] = function(...args) {
+  const original = consoleRef[method];
+  consoleRef[method] = function(...args) {
     args.reduce(function(buf, arg) {
       buf.push(internals.prepLogs(arg));
       return buf;
     }, internals.buffer);
-    original.apply(console, args);
+    original.apply(consoleRef, args);
     internals.flush();
   };
 };
 
 internals.clear = function() {
-  const consoleClear = console.clear;
-  console.clear = function() {
+  const consoleClear = consoleRef.clear;
+  consoleRef.clear = function() {
     internals.buffer = [];
     consoleLogElement.textContent = '';
-    consoleClear.call(console);
+    consoleClear.call(consoleRef);
   };
 };
 
-reporter.main = function() {
+reporter.main = function(options) {
+  consoleLogElement = options.consoleLogElement
+  consoleRef = options.consoleRef;
   internals.clear();
+  internals.buffer = [];
   internals.logMethods.reduce(function(fn, method) {
     fn(method);
     return fn;

--- a/lib/js/pretty.js
+++ b/lib/js/pretty.js
@@ -1,8 +1,7 @@
 import prettyJS from 'pretty-js';
-const prettyBtn = document.querySelector('.pretty-console');
 
-export default (output) => {
-  prettyBtn.addEventListener('click', function prettify() {
-    output.setValue(prettyJS(output.getValue()));
+export default function bindPrettyButton(options) {
+  options.btnPretty.addEventListener('click', function prettify() {
+    options.output.setValue(prettyJS(options.output.getValue()));
   });
-};
+}

--- a/lib/js/repl.js
+++ b/lib/js/repl.js
@@ -5,7 +5,7 @@ import queryString from 'query-string';
 import bindClearButton from './clear';
 import reporter from './logger';
 import bindResetButton from './reset';
-import prettyBtn from './pretty';
+import bindPrettyBtn from './pretty';
 import bindShortUrlButton from './googl';
 const babel = require('babel-core');
 
@@ -115,7 +115,10 @@ bindShortUrlButton({
   urlOut: document.getElementById('urlout')
 });
 
-prettyBtn(output);
+bindPrettyBtn({
+  btnPretty: document.querySelector('.pretty-console'),
+  output: output
+});
 
 // Get source code from 'code' params and paste it into editor
 // The 'code' param is actually located in a hash URL fragment,

--- a/lib/js/repl.js
+++ b/lib/js/repl.js
@@ -2,8 +2,9 @@ const es2015 = require('babel-preset-es2015');
 const stage0 = require('babel-preset-stage-0');
 import debounce from 'debounce';
 import queryString from 'query-string';
+import bindClearButton from './clear';
 import reporter from './logger';
-import resetBtn from './reset';
+import bindResetButton from './reset';
 import prettyBtn from './pretty';
 import googl from './googl';
 const babel = require('babel-core');
@@ -97,7 +98,16 @@ input.on('change', debounceCompile);
 
 const output = CodeMirror.fromTextArea(document.querySelector('.output'), outputConfig);
 
-resetBtn(output);
+bindResetButton({
+  btnReset : document.getElementById('resetBtn'),
+  window : window
+});
+
+bindClearButton({
+  btnClear: document.querySelector('.clear-console'),
+  evalError: document.querySelector('pre.error'),
+  output: output
+});
 
 prettyBtn(output);
 

--- a/lib/js/repl.js
+++ b/lib/js/repl.js
@@ -61,8 +61,6 @@ const compile = function compile() {
   }
 };
 
-reporter.main();
-
 googl();
 
 const debounceCompile = debounce(compile, 1000);
@@ -97,6 +95,11 @@ CodeMirror.registerHelper('instance', 'input', input);
 input.on('change', debounceCompile);
 
 const output = CodeMirror.fromTextArea(document.querySelector('.output'), outputConfig);
+
+reporter.main({
+  consoleLogElement : document.querySelector('.console-log'),
+  consoleRef : window.console
+});
 
 bindResetButton({
   btnReset : document.getElementById('resetBtn'),

--- a/lib/js/repl.js
+++ b/lib/js/repl.js
@@ -6,7 +6,7 @@ import bindClearButton from './clear';
 import reporter from './logger';
 import bindResetButton from './reset';
 import prettyBtn from './pretty';
-import googl from './googl';
+import bindShortUrlButton from './googl';
 const babel = require('babel-core');
 
 const evalError = document.querySelector('pre.error');
@@ -61,8 +61,6 @@ const compile = function compile() {
   }
 };
 
-googl();
-
 const debounceCompile = debounce(compile, 1000);
 
 const codeMirrorConfig = {
@@ -97,19 +95,24 @@ input.on('change', debounceCompile);
 const output = CodeMirror.fromTextArea(document.querySelector('.output'), outputConfig);
 
 reporter.main({
-  consoleLogElement : document.querySelector('.console-log'),
-  consoleRef : window.console
+  consoleLogElement: document.querySelector('.console-log'),
+  consoleRef: window.console
 });
 
 bindResetButton({
-  btnReset : document.getElementById('resetBtn'),
-  window : window
+  btnReset: document.getElementById('resetBtn'),
+  window: window
 });
 
 bindClearButton({
   btnClear: document.querySelector('.clear-console'),
   evalError: document.querySelector('pre.error'),
   output: output
+});
+
+bindShortUrlButton({
+  btnMakeShortUrl: document.getElementById('mkurl'),
+  urlOut: document.getElementById('urlout')
 });
 
 prettyBtn(output);

--- a/lib/js/reset.js
+++ b/lib/js/reset.js
@@ -1,12 +1,7 @@
-const resetBtn = document.getElementById('resetBtn');
-const clearBtn = document.querySelector('.clear-console');
-const evalError = document.querySelector('pre.error');
+export default function bindResetButton(options) {
 
-export default (output) => {
-  resetBtn.addEventListener('click', () => window.location = '.');
-  clearBtn.addEventListener('click', () => {
-    console.clear();
-    output.setValue('');
-    evalError.textContent = '';
+  options.btnReset.addEventListener('click', () => {
+    options.window.location = '.';
   });
-};
+
+}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -19,7 +19,8 @@
       "dependencies": {
         "acorn": {
           "version": "2.7.0",
-          "from": "acorn@>=2.1.0 <3.0.0"
+          "from": "acorn@2.7.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
         }
       }
     },
@@ -30,7 +31,8 @@
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "from": "acorn@>=3.0.4 <4.0.0"
+          "from": "acorn@3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
         }
       }
     },
@@ -1192,6 +1194,11 @@
       "from": "extsprintf@1.0.2",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
     },
+    "fake-xml-http-request": {
+      "version": "1.4.0",
+      "from": "fake-xml-http-request@>=1.4.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/fake-xml-http-request/-/fake-xml-http-request-1.4.0.tgz"
+    },
     "fast-levenshtein": {
       "version": "1.1.4",
       "from": "fast-levenshtein@>=1.1.0 <2.0.0",
@@ -1384,7 +1391,8 @@
       "dependencies": {
         "glob": {
           "version": "7.0.6",
-          "from": "glob@>=7.0.3 <8.0.0"
+          "from": "glob@7.0.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz"
         },
         "minimatch": {
           "version": "3.0.3",
@@ -1557,7 +1565,8 @@
       "dependencies": {
         "lodash": {
           "version": "4.15.0",
-          "from": "lodash@>=4.3.0 <5.0.0"
+          "from": "lodash@4.15.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz"
         }
       }
     },
@@ -2420,11 +2429,13 @@
       "dependencies": {
         "glob": {
           "version": "7.0.6",
-          "from": "glob@>=7.0.5 <8.0.0"
+          "from": "glob@7.0.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz"
         },
         "minimatch": {
           "version": "3.0.3",
-          "from": "minimatch@>=3.0.2 <4.0.0"
+          "from": "minimatch@3.0.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
         }
       }
     },
@@ -2571,7 +2582,8 @@
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0"
+          "from": "isarray@1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
           "version": "2.1.5",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,10 +2,26 @@
   "name": "ramda-repl",
   "version": "1.0.0",
   "dependencies": {
+    "abab": {
+      "version": "1.0.3",
+      "from": "abab@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz"
+    },
     "acorn": {
       "version": "1.2.2",
       "from": "acorn@>=1.0.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+    },
+    "acorn-globals": {
+      "version": "1.0.9",
+      "from": "acorn-globals@>=1.0.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
+      "dependencies": {
+        "acorn": {
+          "version": "2.7.0",
+          "from": "acorn@>=2.1.0 <3.0.0"
+        }
+      }
     },
     "acorn-jsx": {
       "version": "3.0.1",
@@ -63,6 +79,11 @@
       "from": "arr-flatten@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
     },
+    "array-equal": {
+      "version": "1.0.0",
+      "from": "array-equal@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz"
+    },
     "array-filter": {
       "version": "0.0.1",
       "from": "array-filter@>=0.0.0 <0.1.0",
@@ -98,6 +119,11 @@
       "from": "arrify@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
     },
+    "asn1": {
+      "version": "0.2.3",
+      "from": "asn1@>=0.2.3 <0.3.0",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+    },
     "asn1.js": {
       "version": "4.8.0",
       "from": "asn1.js@>=4.0.0 <5.0.0",
@@ -107,6 +133,11 @@
       "version": "1.3.0",
       "from": "assert@>=1.3.0 <1.4.0",
       "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
+    },
+    "assert-plus": {
+      "version": "0.2.0",
+      "from": "assert-plus@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
     },
     "astw": {
       "version": "2.0.0",
@@ -122,6 +153,16 @@
       "version": "1.0.1",
       "from": "async-each@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz"
+    },
+    "aws-sign2": {
+      "version": "0.6.0",
+      "from": "aws-sign2@>=0.6.0 <0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+    },
+    "aws4": {
+      "version": "1.4.1",
+      "from": "aws4@>=1.2.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz"
     },
     "babel-code-frame": {
       "version": "6.3.13",
@@ -490,10 +531,27 @@
       "from": "base64-js@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.1.2.tgz"
     },
+    "bcrypt-pbkdf": {
+      "version": "1.0.0",
+      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+      "dependencies": {
+        "tweetnacl": {
+          "version": "0.14.3",
+          "from": "tweetnacl@>=0.14.3 <0.15.0",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
+        }
+      }
+    },
     "binary-extensions": {
       "version": "1.6.0",
       "from": "binary-extensions@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.6.0.tgz"
+    },
+    "bl": {
+      "version": "1.1.2",
+      "from": "bl@>=1.1.2 <1.2.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz"
     },
     "bluebird": {
       "version": "3.4.6",
@@ -504,6 +562,11 @@
       "version": "4.11.6",
       "from": "bn.js@>=4.1.1 <5.0.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz"
+    },
+    "boom": {
+      "version": "2.10.1",
+      "from": "boom@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
     },
     "brace-expansion": {
       "version": "1.1.2",
@@ -529,6 +592,11 @@
       "version": "1.11.2",
       "from": "browser-resolve@>=1.11.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz"
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "from": "browser-stdout@1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz"
     },
     "browserify": {
       "version": "13.1.0",
@@ -614,6 +682,11 @@
       "from": "camelcase@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
     },
+    "caseless": {
+      "version": "0.11.0",
+      "from": "caseless@>=0.11.0 <0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+    },
     "center-align": {
       "version": "0.1.3",
       "from": "center-align@>=0.1.1 <0.2.0",
@@ -685,6 +758,16 @@
       "version": "0.7.2",
       "from": "combine-source-map@>=0.7.1 <0.8.0",
       "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz"
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "from": "combined-stream@>=1.0.5 <1.1.0",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+    },
+    "commander": {
+      "version": "2.9.0",
+      "from": "commander@2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
     },
     "complexion": {
       "version": "0.1.3",
@@ -758,15 +841,42 @@
       "from": "create-hmac@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz"
     },
+    "cryptiles": {
+      "version": "2.0.5",
+      "from": "cryptiles@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+    },
     "crypto-browserify": {
       "version": "3.11.0",
       "from": "crypto-browserify@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz"
     },
+    "cssom": {
+      "version": "0.3.1",
+      "from": "cssom@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.1.tgz"
+    },
+    "cssstyle": {
+      "version": "0.2.37",
+      "from": "cssstyle@>=0.2.36 <0.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz"
+    },
     "d": {
       "version": "0.1.1",
       "from": "d@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+    },
+    "dashdash": {
+      "version": "1.14.0",
+      "from": "dashdash@>=1.12.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+        }
+      }
     },
     "date-now": {
       "version": "1.0.1",
@@ -803,6 +913,11 @@
       "from": "del@>=2.0.2 <3.0.0",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz"
     },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "from": "delayed-stream@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+    },
     "deps-sort": {
       "version": "2.0.0",
       "from": "deps-sort@>=2.0.0 <3.0.0",
@@ -822,6 +937,11 @@
       "version": "4.3.1",
       "from": "detective@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz"
+    },
+    "diff": {
+      "version": "1.4.0",
+      "from": "diff@1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
     },
     "diffie-hellman": {
       "version": "5.0.2",
@@ -854,6 +974,11 @@
       "version": "3.4.2",
       "from": "duplexify@>=3.2.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz"
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
     },
     "ecstatic": {
       "version": "1.4.1",
@@ -904,6 +1029,23 @@
       "version": "1.0.4",
       "from": "escape-string-regexp@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+    },
+    "escodegen": {
+      "version": "1.8.1",
+      "from": "escodegen@>=1.6.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+      "dependencies": {
+        "estraverse": {
+          "version": "1.9.3",
+          "from": "estraverse@>=1.9.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+        },
+        "source-map": {
+          "version": "0.2.0",
+          "from": "source-map@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz"
+        }
+      }
     },
     "escope": {
       "version": "3.6.0",
@@ -1035,10 +1177,20 @@
       "from": "expand-range@>=1.8.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz"
     },
+    "extend": {
+      "version": "3.0.0",
+      "from": "extend@>=3.0.0 <3.1.0",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+    },
     "extglob": {
       "version": "0.3.2",
       "from": "extglob@>=0.3.1 <0.4.0",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
+    },
+    "extsprintf": {
+      "version": "1.0.2",
+      "from": "extsprintf@1.0.2",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
     },
     "fast-levenshtein": {
       "version": "1.1.4",
@@ -1109,6 +1261,33 @@
       "from": "for-own@>=0.1.3 <0.2.0",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz"
     },
+    "forever-agent": {
+      "version": "0.6.1",
+      "from": "forever-agent@>=0.6.1 <0.7.0",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+    },
+    "form-data": {
+      "version": "1.0.1",
+      "from": "form-data@>=1.0.0-rc4 <1.1.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+      "dependencies": {
+        "async": {
+          "version": "2.0.1",
+          "from": "async@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz"
+        },
+        "lodash": {
+          "version": "4.15.0",
+          "from": "lodash@>=4.8.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz"
+        }
+      }
+    },
+    "formatio": {
+      "version": "1.1.1",
+      "from": "formatio@1.1.1",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz"
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "from": "fs.realpath@>=1.0.0 <2.0.0",
@@ -1138,6 +1317,18 @@
       "version": "4.0.1",
       "from": "get-stdin@>=4.0.1 <5.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+    },
+    "getpass": {
+      "version": "0.1.6",
+      "from": "getpass@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+        }
+      }
     },
     "glob": {
       "version": "4.5.3",
@@ -1239,6 +1430,21 @@
       "from": "graceful-fs@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
     },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "from": "graceful-readlink@>=1.0.0",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+    },
+    "growl": {
+      "version": "1.9.2",
+      "from": "growl@1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz"
+    },
+    "har-validator": {
+      "version": "2.0.6",
+      "from": "har-validator@>=2.0.6 <2.1.0",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
+    },
     "has": {
       "version": "1.0.1",
       "from": "has@>=1.0.0 <2.0.0",
@@ -1249,15 +1455,30 @@
       "from": "has-ansi@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
     },
+    "has-flag": {
+      "version": "1.0.0",
+      "from": "has-flag@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+    },
     "hash.js": {
       "version": "1.0.3",
       "from": "hash.js@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
     },
+    "hawk": {
+      "version": "3.1.3",
+      "from": "hawk@>=3.1.3 <3.2.0",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+    },
     "he": {
       "version": "0.5.0",
       "from": "he@>=0.5.0 <0.6.0",
       "resolved": "https://registry.npmjs.org/he/-/he-0.5.0.tgz"
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "from": "hoek@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
     },
     "home-or-tmp": {
       "version": "1.0.0",
@@ -1279,10 +1500,20 @@
       "from": "http-server@latest",
       "resolved": "https://registry.npmjs.org/http-server/-/http-server-0.9.0.tgz"
     },
+    "http-signature": {
+      "version": "1.1.1",
+      "from": "http-signature@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
+    },
     "https-browserify": {
       "version": "0.0.1",
       "from": "https-browserify@>=0.0.0 <0.1.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz"
+    },
+    "iconv-lite": {
+      "version": "0.4.13",
+      "from": "iconv-lite@>=0.4.13 <0.5.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
     },
     "ieee754": {
       "version": "1.1.6",
@@ -1435,6 +1666,11 @@
       "from": "is-resolvable@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz"
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "from": "is-typedarray@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+    },
     "is-utf8": {
       "version": "0.2.1",
       "from": "is-utf8@>=0.2.0 <0.3.0",
@@ -1457,6 +1693,16 @@
         }
       }
     },
+    "isstream": {
+      "version": "0.1.2",
+      "from": "isstream@>=0.1.2 <0.2.0",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+    },
+    "jodid25519": {
+      "version": "1.0.2",
+      "from": "jodid25519@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+    },
     "js-tokens": {
       "version": "1.0.2",
       "from": "js-tokens@>=1.0.1 <2.0.0",
@@ -1467,15 +1713,47 @@
       "from": "js-yaml@>=3.5.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz"
     },
+    "jsbn": {
+      "version": "0.1.0",
+      "from": "jsbn@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+    },
+    "jsdom": {
+      "version": "9.5.0",
+      "from": "jsdom@latest",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.5.0.tgz",
+      "dependencies": {
+        "acorn": {
+          "version": "2.7.0",
+          "from": "acorn@>=2.4.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
+        }
+      }
+    },
     "jsesc": {
       "version": "0.5.0",
       "from": "jsesc@>=0.5.0 <0.6.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
     },
+    "json-schema": {
+      "version": "0.2.3",
+      "from": "json-schema@0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+    },
     "json-stable-stringify": {
       "version": "0.0.1",
       "from": "json-stable-stringify@>=0.0.0 <0.1.0",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz"
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+    },
+    "json3": {
+      "version": "3.3.2",
+      "from": "json3@3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
     },
     "json5": {
       "version": "0.4.0",
@@ -1501,6 +1779,11 @@
       "version": "1.1.4",
       "from": "JSONStream@>=1.0.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.4.tgz"
+    },
+    "jsprim": {
+      "version": "1.3.1",
+      "from": "jsprim@>=1.2.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz"
     },
     "kind-of": {
       "version": "3.0.2",
@@ -1542,10 +1825,60 @@
       "from": "lodash@>=3.10.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
     },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "from": "lodash._baseassign@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz"
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "from": "lodash._basecreate@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz"
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "from": "lodash._getnative@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "from": "lodash.create@3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz"
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz"
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "from": "lodash.keys@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+    },
     "lodash.memoize": {
       "version": "3.0.4",
       "from": "lodash.memoize@>=3.0.3 <3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz"
+    },
+    "lolex": {
+      "version": "1.3.2",
+      "from": "lolex@1.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz"
     },
     "longest": {
       "version": "1.0.1",
@@ -1594,6 +1927,16 @@
       "from": "mime@>=1.2.11 <2.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
     },
+    "mime-db": {
+      "version": "1.23.0",
+      "from": "mime-db@>=1.23.0 <1.24.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+    },
+    "mime-types": {
+      "version": "2.1.11",
+      "from": "mime-types@>=2.1.7 <2.2.0",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz"
+    },
     "minimalistic-assert": {
       "version": "1.0.0",
       "from": "minimalistic-assert@>=1.0.0 <2.0.0",
@@ -1621,6 +1964,33 @@
         }
       }
     },
+    "mocha": {
+      "version": "3.0.2",
+      "from": "mocha@latest",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.0.2.tgz",
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "from": "escape-string-regexp@1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+        },
+        "glob": {
+          "version": "7.0.5",
+          "from": "glob@7.0.5",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz"
+        },
+        "minimatch": {
+          "version": "3.0.3",
+          "from": "minimatch@>=3.0.2 <4.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "from": "supports-color@3.1.2",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+        }
+      }
+    },
     "module-deps": {
       "version": "4.0.7",
       "from": "module-deps@>=4.0.2 <5.0.0",
@@ -1641,6 +2011,11 @@
       "from": "natural-compare@>=1.4.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
     },
+    "node-uuid": {
+      "version": "1.4.7",
+      "from": "node-uuid@>=1.4.7 <1.5.0",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+    },
     "normalize-path": {
       "version": "2.0.1",
       "from": "normalize-path@>=2.0.1 <3.0.0",
@@ -1650,6 +2025,16 @@
       "version": "1.0.0",
       "from": "number-is-nan@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+    },
+    "nwmatcher": {
+      "version": "1.3.8",
+      "from": "nwmatcher@>=1.3.7 <2.0.0",
+      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.8.tgz"
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "from": "oauth-sign@>=0.8.1 <0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
     },
     "object-assign": {
       "version": "4.0.1",
@@ -1749,6 +2134,11 @@
       "version": "3.0.4",
       "from": "parse-glob@>=3.0.4 <4.0.0",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz"
+    },
+    "parse5": {
+      "version": "1.5.1",
+      "from": "parse5@>=1.5.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz"
     },
     "path-browserify": {
       "version": "0.0.0",
@@ -1981,6 +2371,18 @@
       "from": "repeating@>=1.1.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz"
     },
+    "request": {
+      "version": "2.74.0",
+      "from": "request@>=2.55.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+      "dependencies": {
+        "qs": {
+          "version": "6.2.1",
+          "from": "qs@>=6.2.0 <6.3.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz"
+        }
+      }
+    },
     "require-uncached": {
       "version": "1.0.2",
       "from": "require-uncached@>=1.0.2 <2.0.0",
@@ -2041,6 +2443,11 @@
       "from": "rx-lite@>=3.1.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
     },
+    "samsam": {
+      "version": "1.1.2",
+      "from": "samsam@1.1.2",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz"
+    },
     "sanctuary": {
       "version": "0.7.0",
       "from": "sanctuary@0.7.0",
@@ -2052,6 +2459,11 @@
           "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.17.1.tgz"
         }
       }
+    },
+    "sax": {
+      "version": "1.2.1",
+      "from": "sax@>=1.1.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz"
     },
     "set-immediate-shim": {
       "version": "1.0.1",
@@ -2088,6 +2500,11 @@
       "from": "sigmund@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
     },
+    "sinon": {
+      "version": "1.17.5",
+      "from": "sinon@latest",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.5.tgz"
+    },
     "slash": {
       "version": "1.0.0",
       "from": "slash@>=1.0.0 <2.0.0",
@@ -2097,6 +2514,11 @@
       "version": "0.0.4",
       "from": "slice-ansi@0.0.4",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz"
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "from": "sntp@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
     },
     "source-map": {
       "version": "0.5.3",
@@ -2119,6 +2541,18 @@
       "version": "1.0.3",
       "from": "sprintf-js@>=1.0.2 <1.1.0",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+    },
+    "sshpk": {
+      "version": "1.10.0",
+      "from": "sshpk@>=1.7.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.0.tgz",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+        }
+      }
     },
     "stream-browserify": {
       "version": "2.0.1",
@@ -2166,6 +2600,11 @@
       "from": "string-width@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
     },
+    "stringstream": {
+      "version": "0.0.5",
+      "from": "stringstream@>=0.0.4 <0.1.0",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+    },
     "strip-ansi": {
       "version": "3.0.0",
       "from": "strip-ansi@>=3.0.0 <4.0.0",
@@ -2190,6 +2629,11 @@
       "version": "2.0.0",
       "from": "supports-color@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+    },
+    "symbol-tree": {
+      "version": "3.1.4",
+      "from": "symbol-tree@>=3.1.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.1.4.tgz"
     },
     "syntax-error": {
       "version": "1.1.6",
@@ -2249,6 +2693,16 @@
       "from": "to-fast-properties@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
     },
+    "tough-cookie": {
+      "version": "2.3.1",
+      "from": "tough-cookie@>=2.3.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "from": "tr46@>=0.0.3 <0.1.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz"
+    },
     "trim-right": {
       "version": "1.0.1",
       "from": "trim-right@>=1.0.1 <2.0.0",
@@ -2264,10 +2718,20 @@
       "from": "tty-browserify@>=0.0.0 <0.1.0",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
     },
+    "tunnel-agent": {
+      "version": "0.4.3",
+      "from": "tunnel-agent@>=0.4.1 <0.5.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+    },
     "tv4": {
       "version": "1.2.7",
       "from": "tv4@>=1.2.7 <2.0.0",
       "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.2.7.tgz"
+    },
+    "tweetnacl": {
+      "version": "0.13.3",
+      "from": "tweetnacl@>=0.13.0 <0.14.0",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
     },
     "type-check": {
       "version": "0.3.2",
@@ -2343,6 +2807,11 @@
       "from": "util-deprecate@>=1.0.1 <1.1.0",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
     },
+    "verror": {
+      "version": "1.3.6",
+      "from": "verror@1.3.6",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+    },
     "vinyl": {
       "version": "0.4.6",
       "from": "vinyl@>=0.4.0 <0.5.0",
@@ -2380,6 +2849,16 @@
       "from": "watchify@latest",
       "resolved": "https://registry.npmjs.org/watchify/-/watchify-3.7.0.tgz"
     },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "from": "webidl-conversions@>=3.0.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
+    },
+    "whatwg-url": {
+      "version": "3.0.0",
+      "from": "whatwg-url@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-3.0.0.tgz"
+    },
     "window-size": {
       "version": "0.1.0",
       "from": "window-size@0.1.0",
@@ -2399,6 +2878,11 @@
       "version": "0.2.1",
       "from": "write@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
+    },
+    "xml-name-validator": {
+      "version": "2.0.1",
+      "from": "xml-name-validator@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz"
     },
     "xregexp": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "git://github.com/ramda/ramda.github.io.git"
   },
   "scripts": {
-    "test": "mocha --compilers js:babel-core/register --reporter spec",
+    "test": "mocha",
     "server": "http-server",
     "lint": "eslint lib/*.js",
     "dev": "watchify ./lib/js/main.js -t babelify ./lib/js/repl.js -o ./lib/js/bundle.js -v",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "eslint": "^3.5.0",
+    "fake-xml-http-request": "^1.4.0",
     "http-server": "^0.9.0",
     "jsdom": "^9.5.0",
     "mocha": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "url": "git://github.com/ramda/ramda.github.io.git"
   },
   "scripts": {
+    "test": "mocha --compilers js:babel-core/register --reporter spec",
     "server": "http-server",
     "lint": "eslint lib/*.js",
     "dev": "watchify ./lib/js/main.js -t babelify ./lib/js/repl.js -o ./lib/js/bundle.js -v",
@@ -33,6 +34,9 @@
   "devDependencies": {
     "eslint": "^3.5.0",
     "http-server": "^0.9.0",
+    "jsdom": "^9.5.0",
+    "mocha": "^3.0.2",
+    "sinon": "^1.17.5",
     "watchify": "^3.7.0"
   }
 }

--- a/test/clear.test.js
+++ b/test/clear.test.js
@@ -1,0 +1,71 @@
+import assert from 'assert';
+import jsdom from 'jsdom';
+import R from 'ramda';
+import sinon from 'sinon';
+
+import bindClearButton from '../lib/js/clear';
+
+describe('Clicking the "clear" button', function() {
+
+  const errMsg = 'An error is present';
+
+  let errMsgEl,
+    btnClearEl,
+    output;
+
+  beforeEach(function() {
+
+    const doc = jsdom.jsdom(`
+      <div class="err-msg">
+        ${errMsg}
+      </div>
+      <button class="btn-clear"></button>
+    `);
+
+    errMsgEl = doc.querySelector('.err-msg');
+    btnClearEl = doc.querySelector('.btn-clear');
+    output = {
+      setValue : sinon.spy()
+    };
+
+    console.clear = sinon.spy();
+
+    bindClearButton({
+      btnClear : btnClearEl,
+      evalError : errMsgEl,
+      output
+    });
+
+  });
+
+  it('should clear the console', function() {
+
+    assert.equal(false, console.clear.calledOnce);
+
+    btnClearEl.click();
+
+    assert(console.clear.calledOnce);
+
+  });
+
+  it('should clear the error message text', function() {
+
+    assert.ok(R.contains(errMsg, errMsgEl.textContent));
+
+    btnClearEl.click();
+
+    assert(R.isEmpty(errMsgEl.textContent));
+
+  });
+
+  it('should clear the output text', function() {
+
+    assert.equal(false, output.setValue.calledOnce);
+
+    btnClearEl.click();
+
+    assert(output.setValue.calledOnce);
+
+  });
+
+});

--- a/test/googl.test.js
+++ b/test/googl.test.js
@@ -6,7 +6,7 @@ import FakeXHR from 'fake-xml-http-request';
 
 import bindShortUrlButton from '../lib/js/googl';
 
-describe.only('Clicking the "Make short URL" button', function() {
+describe('Clicking the "Make short URL" button', function() {
 
   const locationHash = 'location-hash';
 

--- a/test/googl.test.js
+++ b/test/googl.test.js
@@ -11,8 +11,7 @@ describe('Clicking the "Make short URL" button', function() {
   const locationHash = 'location-hash';
 
   let btnMakeShortUrl,
-    urlOut,
-    consoleRef;
+    urlOut;
 
   let requests = [];
 
@@ -38,7 +37,7 @@ describe('Clicking the "Make short URL" button', function() {
     // The request data presumes a global location.hash
     global.location = { hash : locationHash };
 
-    consoleRef = { error : sinon.spy() };
+    console.error = sinon.spy();
 
   });
 
@@ -48,7 +47,7 @@ describe('Clicking the "Make short URL" button', function() {
 
   it('should invoke a request for a short url', function() {
 
-    bindShortUrlButton({ btnMakeShortUrl, urlOut, consoleRef });
+    bindShortUrlButton({ btnMakeShortUrl, urlOut });
 
     btnMakeShortUrl.click();
 
@@ -59,19 +58,19 @@ describe('Clicking the "Make short URL" button', function() {
 
   it('calls console.error when an XHR error occurs', function() {
 
-    bindShortUrlButton({ btnMakeShortUrl, urlOut, consoleRef });
+    bindShortUrlButton({ btnMakeShortUrl, urlOut });
 
     btnMakeShortUrl.click();
 
     R.head(requests).dispatchEvent({ type : 'error' });
 
-    sinon.assert.called(consoleRef.error);
+    sinon.assert.called(console.error);
 
   });
 
   it('sets success responses in the DOM', function() {
 
-    bindShortUrlButton({ btnMakeShortUrl, urlOut, consoleRef });
+    bindShortUrlButton({ btnMakeShortUrl, urlOut });
 
     btnMakeShortUrl.click();
 

--- a/test/googl.test.js
+++ b/test/googl.test.js
@@ -1,0 +1,90 @@
+import assert from 'assert';
+import jsdom from 'jsdom';
+import R from 'ramda';
+import sinon from 'sinon';
+
+import bindShortUrlButton from '../lib/js/googl';
+
+describe.only('Clicking the "Make short URL" button', function() {
+
+  const locationHash = 'location-hash';
+
+  let btnMakeShortUrl,
+    urlOut,
+    xhr,
+    consoleRef;
+
+  let requests = [];
+
+  beforeEach(function() {
+
+    const doc = jsdom.jsdom(`
+      <input class="url-out" type="text"/>
+      <button class="btn-url"></button>
+    `);
+
+    btnMakeShortUrl = doc.querySelector('.btn-url'),
+    urlOut          = doc.querySelector('.url-out');
+
+    // Example: using sinon to mock XMLHttpRequest
+    // https://github.com/scriptare/compago-ajax/blob/master/tests/unit.test.js#L36
+    xhr = sinon.useFakeXMLHttpRequest();
+    global.XMLHttpRequest = xhr;
+    global.XMLHttpRequest = sinon.useFakeXMLHttpRequest();
+    xhr.onCreate = xhr => requests.push(xhr);
+
+    // The request data presumes a global location.hash
+    global.location = { hash : locationHash };
+
+    consoleRef = { error : sinon.spy() };
+
+  });
+
+  afterEach(function() {
+    requests = [];
+    xhr.restore();
+  });
+
+  it('should invoke a request for a short url', function() {
+
+    bindShortUrlButton({ btnMakeShortUrl, urlOut, consoleRef });
+
+    btnMakeShortUrl.click();
+
+    assert.equal(1, requests.length);
+    assert(R.contains(global.location.hash, R.head(requests).requestBody));
+
+  });
+
+  it('calls console.error when an XHR error occurs', function() {
+
+    bindShortUrlButton({ btnMakeShortUrl, urlOut, consoleRef });
+
+    btnMakeShortUrl.click();
+
+    const request = R.head(requests);
+    request.dispatchEvent(new sinon.Event('error', false, false, xhr));
+
+    sinon.assert.called(consoleRef.error);
+
+  });
+
+/*
+ *  it('sets success responses in the DOM', function() {
+ *
+ *    bindShortUrlButton({ btnMakeShortUrl, urlOut, consoleRef });
+ *
+ *    btnMakeShortUrl.click();
+ *
+ *    const request = R.head(requests);
+ *    const responseBody = 'ramda';
+ *
+ *    request.respond(500, { 'Content-Type': 'text/plain' }, responseBody);
+ *    request.dispatchEvent(new sinon.Event('load'));
+ *
+ *    assert.equal(responseBody, urlOut.textContent);
+ *
+ *  });
+ */
+
+});

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -1,0 +1,71 @@
+import assert from 'assert';
+import jsdom from 'jsdom';
+import R from 'ramda';
+import sinon from 'sinon';
+
+import reporter from '../lib/js/logger';
+
+describe('reporter', function() {
+
+  let consoleMock,
+    logEl;
+
+  beforeEach(function() {
+
+    const doc = jsdom.jsdom('<div class="console-log"></div>');
+
+    consoleMock = ['clear', 'log', 'info', 'debug'].reduce((o, method) => {
+      o[method] = sinon.spy();
+      return o;
+    }, {});
+
+    logEl = doc.querySelector('.console-log');
+
+  });
+
+  describe('.main', function() {
+
+    const text = 'ramda';
+
+    it('will decorate console.clear', function() {
+
+      reporter.main({
+        consoleLogElement : logEl,
+        consoleRef : consoleMock
+      });
+
+      logEl.textContent = text;
+
+      consoleMock.clear();
+
+      assert(R.isEmpty(logEl.textContent));
+
+    });
+
+    ['log', 'info', 'debug'].forEach(method => {
+
+      it(`will decorate console.${method}`, function() {
+
+        logEl.textContent = '';
+
+        reporter.main({
+          consoleLogElement : logEl,
+          consoleRef : consoleMock
+        });
+
+        consoleMock[method](text);
+
+        assert.equal(text, logEl.textContent);
+
+        consoleMock[method](text);
+
+        assert.equal(`${text}\n${text}`, logEl.textContent);
+
+      });
+
+    });
+
+
+  });
+
+});

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -27,7 +27,7 @@ describe('reporter', function() {
 
     const text = 'ramda';
 
-    it('will decorate console.clear', function() {
+    it('will intercept console.clear, clearing the in-DOM log', function() {
 
       reporter.main({
         consoleLogElement : logEl,
@@ -44,27 +44,101 @@ describe('reporter', function() {
 
     ['log', 'info', 'debug'].forEach(method => {
 
-      it(`will decorate console.${method}`, function() {
+      describe(`console.${method} interceptor`, function() {
 
-        logEl.textContent = '';
+        it('will display args in the DOM', function() {
 
-        reporter.main({
-          consoleLogElement : logEl,
-          consoleRef : consoleMock
+          reporter.main({
+            consoleLogElement : logEl,
+            consoleRef : consoleMock
+          });
+
+          consoleMock[method](text);
+
+          assert.equal(text, logEl.textContent);
+
+          consoleMock[method](text);
+
+          assert.equal(`${text}\n${text}`, logEl.textContent);
+
         });
 
-        consoleMock[method](text);
+        it('will display buffered args on multiple lines', function() {
 
-        assert.equal(text, logEl.textContent);
+          reporter.main({
+            consoleLogElement : logEl,
+            consoleRef : consoleMock
+          });
 
-        consoleMock[method](text);
+          consoleMock[method](text);
+          consoleMock[method](text);
+          consoleMock[method](text);
 
-        assert.equal(`${text}\n${text}`, logEl.textContent);
+          assert.equal(`${text}\n${text}\n${text}`, logEl.textContent);
+
+        });
+
+        it('will display string representations of Functions', function() {
+
+          reporter.main({
+            consoleLogElement : logEl,
+            consoleRef : consoleMock
+          });
+
+          consoleMock[method](R.identity);
+
+          assert.equal(R.identity.toString(), logEl.textContent);
+
+        });
+
+        it('will display stringified errors', function() {
+
+          reporter.main({
+            consoleLogElement : logEl,
+            consoleRef : consoleMock
+          });
+
+          const e = new Error('🐑');
+
+          consoleMock[method](e);
+
+          assert.equal(JSON.stringify(e), logEl.textContent);
+
+        });
+
+        it('will display stringified objects', function() {
+
+          reporter.main({
+            consoleLogElement : logEl,
+            consoleRef : consoleMock
+          });
+
+          const o = { baa : '🐑'};
+
+          consoleMock[method](o);
+
+          assert.equal(JSON.stringify(o), logEl.textContent);
+
+        });
+
+        it('will display stringified arrays', function() {
+
+          reporter.main({
+            consoleLogElement : logEl,
+            consoleRef : consoleMock
+          });
+
+          const a = ['🐑'];
+
+          consoleMock[method](a);
+
+          assert.equal(JSON.stringify(a), logEl.textContent);
+
+        });
 
       });
 
     });
-
 
   });
 

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--require babel-register

--- a/test/pretty.test.js
+++ b/test/pretty.test.js
@@ -1,0 +1,41 @@
+import jsdom from 'jsdom';
+import sinon from 'sinon';
+
+import bindPrettyButton from '../lib/js/pretty';
+
+describe('Clicking the "pretty" button', function() {
+
+  let btnPrettyEl,
+    output;
+
+  beforeEach(function() {
+
+    const doc = jsdom.jsdom('<button class="btn-pretty"></button>');
+
+    btnPrettyEl = doc.querySelector('.btn-pretty');
+
+  });
+
+  it('should instruct the "output" CodeMirror to reformat the text', function() {
+
+    const unformattedCode = "['a', 'b', 'c,']";
+    const formattedCode = `[\n    "a",\n    "b",\n    "c,"\n]`;
+
+    output = {
+      setValue : sinon.spy(),
+      getValue : sinon.stub().returns(unformattedCode)
+    };
+
+    bindPrettyButton({
+      btnPretty : btnPrettyEl,
+      output : output
+    });
+
+    btnPrettyEl.click();
+
+    sinon.assert.called(output.getValue);
+    sinon.assert.calledWith(output.setValue, formattedCode);
+
+  });
+
+});

--- a/test/reset.test.js
+++ b/test/reset.test.js
@@ -1,0 +1,36 @@
+import assert from 'assert';
+import jsdom from 'jsdom';
+
+import bindResetButton from '../lib/js/reset';
+
+describe('Clicking the "reset" button', function() {
+
+  it('should return the window location to "."', function() {
+
+    const doc = jsdom.jsdom(`
+      <button class="btn-reset"></button>
+    `);
+
+    const fromLocation = 'qwerty';
+    const toLocation   = '.';
+
+    const win = {
+      location : fromLocation
+    };
+
+    const btnResetEl = doc.querySelector('.btn-reset');
+
+    bindResetButton({
+      btnReset : btnResetEl,
+      window : win
+    });
+
+    assert.equal(win.location, fromLocation);
+
+    btnResetEl.click();
+
+    assert.equal(win.location, toLocation);
+
+  });
+
+});


### PR DESCRIPTION
Relates to: #7 

Hello

Here is a start for some tests - using [mocha](https://github.com/mochajs/mocha), [sinon](http://sinonjs.org/), [jsdom](https://github.com/tmpvar/jsdom) and [fake-xml-http-request](https://github.com/pretenderjs/FakeXMLHttpRequest) - the latter of which I found more effective than the `sinon` fake XHR / fake server utilities for simulating the shortlink request. Alas even so I had to change `response` to `responseText` in `googl.js` as the library did not simulate that property.

I've made a few changes - hopefully not too heavy handed - in order to make testing a little easier: 

- DOM elements are passed to the various bind-listener-to-element files rather than being looked up in those files. Doing so gives us one place (presently `repl.js`) where we can go to to see which selectors are being used to bind to the DOM, and protects the tests from needing to know the specifics of the DOM.

- A reference to the `console` object is being passed to the `logger` (AKA `reporter`); thus we can spy on wrapped console methods without interfering with the console that the test reporter uses to provide feedback.

- The "clear" and "reset" button behaviours now have their own files so each could be imported and tested individually.

I haven't got to testing the actual code input / output panes themselves. This is already a big collection of changes so I figured it appropriate to share before going further.

![output](https://cloud.githubusercontent.com/assets/926283/18614929/b4d5a732-7d90-11e6-85b9-0530cc7cca0d.png)
