### PR TITLE
Fix lints for /lib/js/, and lint tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "test": "mocha",
     "server": "http-server",
-    "lint": "eslint lib/*.js",
+    "lint": "eslint lib/js/*.js; eslint test/*.js",
     "dev": "watchify ./lib/js/main.js -t babelify ./lib/js/repl.js -o ./lib/js/bundle.js -v",
     "build": "browserify ./lib/js/main.js -t babelify ./lib/js/repl.js -o ./lib/js/bundle.js"
   },


### PR DESCRIPTION
Well, that's embarrassing. The linting wasn't pointing at the right directory ...

So I've fixed that, and added linting to the `test` folder as well for good measure. Note that the `bundle.js` file is ignored.