### PR TITLE
Introduce examples folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ A repl (read-eval-print-loop) for [Ramda](http://ramdajs.com/)
 
 You will find a collection of [npm run *](https://docs.npmjs.com/cli/run-script) scripts in [package.json](package.json):
 
-To run a simple server that will host the [index.html](index.html) file:
+To run a simple server that will host the [example/index.html](example/index.html) file:
 
 `npm run server`
 
-This will start serving the _repl_ at [localhost:8080](http://localhost:8080)
+This will start serving the _repl_ at [localhost:8080/example](http://localhost:8080/example)
 
 To build the JavaScript bundle:
 

--- a/example/index.html
+++ b/example/index.html
@@ -16,7 +16,7 @@
     <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
     <![endif]-->
 
-    <link rel="stylesheet" href="dist/bundle.css">
+    <link rel="stylesheet" href="../dist/bundle.css">
 
     <style>
       /* for demonstration only */
@@ -34,9 +34,8 @@
       }
 
       .container {
-        margin : 20px auto;
-        width  : 800px;
-        height : 600px;
+        margin     : 20px auto;
+        width      : 800px;
         box-shadow : 0px 5px 20px rgba(0,0,0,0.7);
       }
       .ramda-repl-target {
@@ -66,7 +65,7 @@ R.evolve(transformations, tomato); //=> {firstName: 'Tomato', data: {elapsed: 10
     <!-- For demonstrating persist-to-queryString -->
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/URI.js/1.18.1/URI.min.js"></script>
 
-    <script src="dist/bundle.js"></script>
+    <script src="../dist/bundle.js"></script>
 
     <script>
 


### PR DESCRIPTION
This moves the index.html file to an examples folder - as that is what it is, I suppose. It is not part of any testing, apart from perhaps manual testing done during development.

Updates the paths in that same file to reference the `dist` folder, and adjusts some example css that presents a not-quite-right looking example layout.

Closes #38 