### PR TITLE
Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ RamdaREPL will do the following operations with respect to the target DOM Node:
   </thead>
   <tbody>
     <tr>
-      <td>`apiURL`</td>
+      <td><code>apiURL</code></td>
       <td>Yes</td>
       <td>String</td>
-      <td>A path to a <a href="https://developers.google.com/url-shortener/">Google url-shortener</a> service endpoint - this will require a specific API key, details <a href="https://developers.google.com/url-shortener/v1/getting_started">here</a>td>
+      <td>A path to a <a href="https://developers.google.com/url-shortener/">Google url-shortener</a> service endpoint - this will require a specific API key, details <a href="https://developers.google.com/url-shortener/v1/getting_started">here</a></td>
       <td>
         <pre lang="js">
 "https://www.googleapis.com/urlshortener/v1/url?key=APIKEY"
@@ -60,7 +60,7 @@ RamdaREPL will do the following operations with respect to the target DOM Node:
       </td>
     </tr>
     <tr>
-      <td>`returnUrl`</td>
+      <td><code>returnUrl</code></td>
       <td>Yes</td>
       <td>String</td>
       <td>A URL (minus query string) that will be used with the url-shortening service to indicate where a sharable link will take user-agents. The current query string will be appended to this. This idea here is that you can have a REPL at <code>http://your-ramda-repl.com#code</code> and have the share feature redirect to <code>http://ramdajs.com/repl#code</code> should you wish.</td>
@@ -71,10 +71,10 @@ RamdaREPL will do the following operations with respect to the target DOM Node:
       </td>
     </tr>
     <tr>
-      <td>`initialValue`</td>
+      <td><code>initialValue</code></td>
       <td>No</td>
       <td>String</td>
-      <td>Used to provide the initial code in the input panel. It overrides the default behaviour, which is to use the content of the `target` element.</td>
+      <td>Used to provide the initial code in the input panel. It overrides the default behaviour, which is to use the content of the <code>target</code> element.</td>
       <td>
         <pre lang="js">
 "identity(1)"
@@ -82,7 +82,7 @@ RamdaREPL will do the following operations with respect to the target DOM Node:
       </td>
     </tr>
     <tr>
-      <td>`onChange`</td>
+      <td><code>onChange</code></td>
       <td>No</td>
       <td>Function</td>
       <td>This is called with the <em>pre-compiled</em> text from the input window whenever this text is changed. This can be used for updating the URL with a new query string, for example.</td>
@@ -93,7 +93,7 @@ RamdaREPL will do the following operations with respect to the target DOM Node:
       </td>
     </tr>
     <tr>
-      <td>`ramdaScript`</td>
+      <td><code>ramdaScript</code></td>
       <td>Yes</td>
       <td>Object - see below</td>
       <td>A script description object used to defined where Ramda is sourced and how it is globally exposed</td>
@@ -107,10 +107,10 @@ RamdaREPL will do the following operations with respect to the target DOM Node:
       </td>
     </tr>
     <tr>
-      <td>`scripts`</td>
+      <td><code>scripts</code></td>
       <td>No</td>
       <td>Array of Objects - see below</td>
-      <td>A list of script description objects used to defined where other interesting libraries are sourced and how it is globally exposed</td>
+      <td>A list of script description objects used to defined where other interesting libraries are sourced and how they are globally exposed</td>
       <td>
         <pre lang="js">
 [
@@ -145,7 +145,7 @@ How the dynamically loaded scripts are made available can defined using objects 
   </thead>
   <tbody>
     <tr>
-      <td>`src` </td>
+      <td><code>src</code> </td>
       <td>Yes</td>
       <td>String</td>
       <td>A URL referencing a JavaScript file</td>
@@ -156,8 +156,8 @@ How the dynamically loaded scripts are made available can defined using objects 
       </td>
     </tr>
     <tr>
-      <td>`global`</td>
-      <td>Yes if `exposeAs` or `expose` are used </td>
+      <td><code>global</code></td>
+      <td>Yes if <code>exposeAs</code> or <code>expose</code> are used </td>
       <td> String </td>
       <td> A name of a global the the script will introduce</td>
       <td>
@@ -167,7 +167,7 @@ How the dynamically loaded scripts are made available can defined using objects 
       </td>
     </tr>
     <tr>
-      <td>`exposeAs`</td>
+      <td><code>exposeAs</code></td>
       <td>No</td>
       <td>String</td>
       <td>The name of a global that will act as an alias to the global introduced by the script</td>
@@ -178,10 +178,10 @@ How the dynamically loaded scripts are made available can defined using objects 
       </td>
     </tr>
     <tr>
-      <td>`expose`</td>
+      <td><code>expose</code></td>
       <td>No</td>
       <td>Array of Strings</td>
-      <td>A list of method names on the `global` that you wish to expose globally. <strong>Given this list is not provided all methods found on the `global` will be exposed</strong></td>
+      <td>A list of method names on the <code>global</code> that you wish to expose globally. <strong>Given this list is not provided all methods found on the <code>global</code> will be exposed</strong></td>
       <td>
         <pre lang="js">
 [

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ RamdaREPL will do the following operations with respect to the target DOM Node:
       <td>`apiURL`</td>
       <td>Yes</td>
       <td>String</td>
-      <td>A path to a [https://developers.google.com/url-shortener/](Google url-shortener) service endpoint - this will require a specific API key, details [here](https://developers.google.com/url-shortener/v1/getting_started)</td>
+      <td>A path to a [Google url-shortener](https://developers.google.com/url-shortener/) service endpoint - this will require a specific API key, details [here](https://developers.google.com/url-shortener/v1/getting_started)</td>
       <td>
         <pre lang="js">
 "https://www.googleapis.com/urlshortener/v1/url?key=APIKEY"
@@ -63,7 +63,7 @@ RamdaREPL will do the following operations with respect to the target DOM Node:
       <td>`returnUrl`</td>
       <td>Yes</td>
       <td>String</td>
-      <td>A URL (minus query string) that will be used with the url-shortening service to indicate where a sharable link will take user-agents. The current query string will be appended to this. This idea here is that you can have a REPL at `http://your-ramda-repl.com#code` and have the share feature redirect to `http://ramdajs.com/repl#code` should you wish.</tdw>
+      <td>A URL (minus query string) that will be used with the url-shortening service to indicate where a sharable link will take user-agents. The current query string will be appended to this. This idea here is that you can have a REPL at `http://your-ramda-repl.com#code` and have the share feature redirect to `http://ramdajs.com/repl#code` should you wish.</td>
       <td>
         <pre lang="js">
 "http://ramdajs.com/repl/"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ A repl (read-eval-print-loop) for [Ramda](http://ramdajs.com/)
 
 [dist/bundle.js](dist/bundle.js) will expose a global function called `ramdaRepl`.
 
-`ramdaRepl` takes two arguments (details to follow) and will immediately attempt to instantiate itself in the DOM.
+`ramdaRepl` is applied to two arguments (details to follow) and will immediately attempt to instantiate itself in the DOM.
+
+An example with all the configuration options set is available [here](example/index.html).
 
 ```js
 ramdaRepl(target, config)
@@ -29,74 +31,31 @@ RamdaREPL will do the following operations relating with respect to the target D
 
 - it will hide the target node
 - it will add itself to the DOM as a sibling to the target node
-- it will look for text within the target node, adding the text to its input panel when it appears (note that this can be overridden in certain circumstances).
+- it will look for text within the target node and will prefill the input panel with this text (this can be overridden by the config)
 
 #### config
 
 `config` is a regular JavaScript object.
 
-```javascript
+|Key|Required|Type|Description|Example|
+|`apiURL`|Yes|String|A path to a [Google url-shortener]( https://developers.google.com/url-shortener/ ) service endpoint - this will require a specific API key, details [here](https://developers.google.com/url-shortener/v1/getting_started) |'https://www.googleapis.com/urlshortener/v1/url?key=<API-KEY>'|
+|`returnUrl`|Yes|String|A URL (minus query string) that will be used with the url-shortening service to indicate where a sharable link will take user-agents. The current query string will be appended to this. This idea here is that you can have a REPL at `http://your-ramda-repl.com#<code>` and have the share feature redirect to `http://ramdajs.com/repl#<code>` should you wish.|'http://ramdajs.com/repl/'|
+|`initialValue`|No|String|Used to provide the initial code in the input panel. It overrides the default behaviour, which is to use the content of the `target` element.|"identity(1)"|
+|`onChange`|No|Function|This is called with the _pre-compiled_ text from the input window whenever this text is changed. This can be used for updating the URL with a new query string, for example.|`(code) => window.location.hash = URI.encode(code)`|
+|`ramdaScript`|Yes|Object - see below|A script description object used to defined where Ramda is sourced and how it is globally exposed|`{ src : '//cdn.jsdelivr.net/ramda/latest/ramda.min.js', global : 'R' }`|
+|`scripts`|No|Array of Objects - see below|A list of script description objects used to defined where other interesting libraries are sourced and how it is globally exposed|`[{src:'//wzrd.in/standalone/sanctuary@latest', global: 'sanctuary', exposeAs : 'S'}]|
 
-var config = {
+The keys `ramdaScript` and `scripts` are used to organise the dynamically loaded scripts that will be available to the REPL, such as `ramda`, `ramda-sanctuary` and `ramda-fantasy`. Ramda is loaded first, as it is presumed that the other libraries will require it to be present before they can be included.
 
-  apiUrl: 'https://www.googleapis.com/urlshortener/v1/url?key=AIzaSyDhbAvT5JqkxFPkoeezJp19-S_mAJudxyk',
-  returnUrl: 'http://ramdajs.com/repl/',
+Organising the scripts includes providing a reference to a URL where the script can be sourced - and adding in optional configuration for how globals will be made available.
 
-  // If unset, initialValue will use the value or textcontent of the
-  // target element.
-  initialValue: URI.decode(window.location.hash).substring(2),
+How the dynamically loaded scripts are made available can defined using objects with the following keys:
 
-  // Called with the pre-compiled content
-  onChange : function(code) {
-    window.location.hash = '?' + URI.encode(code);
-  },
-
-  // The following config defines scripts that will be dynamically
-  // loaded upon creating the REPL. Each has the following properties:
-  //
-  // src      - The source of the script, a URL
-  // global   - (Optional) a name of a global that the script introduces
-  // exposeAs - (Optional) a name that can alias the global
-  // expose   - (Optional) a list of methods to expose globally
-
-  // Required.
-  // As ramda may be a dependency for other scripts, it will
-  // be intentionally loaded before any other script.
-  ramdaScript: {
-    src    : ramdaUrl,
-    global : 'R'
-  },
-
-  // Optional.
-  // Here we can declare a list of libraries that we wish to have
-  // loaded and exposed in the repl.
-  scripts: [
-    {
-      src      : '//wzrd.in/standalone/sanctuary@latest',
-      global   : 'sanctuary',
-      exposeAs : 'S'
-    },
-    {
-      src    : '//wzrd.in/standalone/ramda-fantasy@latest',
-      global : 'ramdaFantasy',
-      expose : [
-        'Either',
-        'Future',
-        'Identity',
-        'IO',
-        'lift2',
-        'lift3',
-        'Maybe',
-        'Tuple',
-        'Reader'
-      ]
-    }
-  ]
-
-};
-
-```
-
+| Key | Required | Type | Description | Example
+|`src` | Yes | String | A URL referencing a JavaScript file | `//cdn.jsdelivr.net/ramda/latest/ramda.min.js` |
+| `global` | Yes if `exposeAs` or `expose` are used | String | A name of a global the the script will introduce | `R` |
+| `exposeAs` | No | String | The name of a global that will act as an alias to the global introduced by the script | `RAMDA` |
+| `expose` | No | Array of Strings | A list of method names on the `global` that you wish to expose globally. *Given this list is not provided all methods found on the `global` will be exposed*  | `[identity, map, filter]` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ RamdaREPL will do the following operations with respect to the target DOM Node:
       <td>`apiURL`</td>
       <td>Yes</td>
       <td>String</td>
-      <td>A path to a [Google url-shortener](https://developers.google.com/url-shortener/) service endpoint - this will require a specific API key, details [here](https://developers.google.com/url-shortener/v1/getting_started)</td>
+      <td>A path to a <a href="https://developers.google.com/url-shortener/">Google url-shortener</a> service endpoint - this will require a specific API key, details <a href="https://developers.google.com/url-shortener/v1/getting_started">here</a>td>
       <td>
         <pre lang="js">
 "https://www.googleapis.com/urlshortener/v1/url?key=APIKEY"
@@ -63,7 +63,7 @@ RamdaREPL will do the following operations with respect to the target DOM Node:
       <td>`returnUrl`</td>
       <td>Yes</td>
       <td>String</td>
-      <td>A URL (minus query string) that will be used with the url-shortening service to indicate where a sharable link will take user-agents. The current query string will be appended to this. This idea here is that you can have a REPL at `http://your-ramda-repl.com#code` and have the share feature redirect to `http://ramdajs.com/repl#code` should you wish.</td>
+      <td>A URL (minus query string) that will be used with the url-shortening service to indicate where a sharable link will take user-agents. The current query string will be appended to this. This idea here is that you can have a REPL at <code>http://your-ramda-repl.com#code</code> and have the share feature redirect to <code>http://ramdajs.com/repl#code</code> should you wish.</td>
       <td>
         <pre lang="js">
 "http://ramdajs.com/repl/"
@@ -85,7 +85,7 @@ RamdaREPL will do the following operations with respect to the target DOM Node:
       <td>`onChange`</td>
       <td>No</td>
       <td>Function</td>
-      <td>This is called with the _pre-compiled_ text from the input window whenever this text is changed. This can be used for updating the URL with a new query string, for example.</td>
+      <td>This is called with the <em>pre-compiled</em> text from the input window whenever this text is changed. This can be used for updating the URL with a new query string, for example.</td>
       <td>
         <pre lang="js">
 (code) => window.location.hash = URI.encode(code)
@@ -181,7 +181,7 @@ How the dynamically loaded scripts are made available can defined using objects 
       <td>`expose`</td>
       <td>No</td>
       <td>Array of Strings</td>
-      <td>A list of method names on the `global` that you wish to expose globally. **Given this list is not provided all methods found on the `global` will be exposed**</td>
+      <td>A list of method names on the `global` that you wish to expose globally. <strong>Given this list is not provided all methods found on the `global` will be exposed</strong></td>
       <td>
         <pre lang="js">
 [

--- a/README.md
+++ b/README.md
@@ -50,10 +50,14 @@ RamdaREPL will do the following operations with respect to the target DOM Node:
   <tbody>
     <tr>
       <td>`apiURL`</td>
-      <td>Yes<td>
+      <td>Yes</td>
       <td>String</td>
       <td>A path to a [Google url-shortener]( https://developers.google.com/url-shortener/ ) service endpoint - this will require a specific API key, details [here](https://developers.google.com/url-shortener/v1/getting_started)</td>
-      <td>`'https://www.googleapis.com/urlshortener/v1/url?key=APIKEY'`</td>
+      <td>
+        <pre lang="js">
+"https://www.googleapis.com/urlshortener/v1/url?key=APIKEY"
+        </pre>
+      </td>
     </tr>
     <tr>
       <td>`returnUrl`</td>

--- a/README.md
+++ b/README.md
@@ -37,14 +37,91 @@ RamdaREPL will do the following operations with respect to the target DOM Node:
 
 `config` is a regular JavaScript object.
 
-|Key|Required|Type|Description|Example|
-|---|--------|----|-----------|-------|
-|`apiURL`|Yes|String|A path to a [Google url-shortener]( https://developers.google.com/url-shortener/ ) service endpoint - this will require a specific API key, details [here](https://developers.google.com/url-shortener/v1/getting_started)|`'https://www.googleapis.com/urlshortener/v1/url?key=APIKEY'`|
-|`returnUrl`|Yes|String|A URL (minus query string) that will be used with the url-shortening service to indicate where a sharable link will take user-agents. The current query string will be appended to this. This idea here is that you can have a REPL at `http://your-ramda-repl.com#<code>` and have the share feature redirect to `http://ramdajs.com/repl#<code>` should you wish.|`'http://ramdajs.com/repl/'`|
-|`initialValue`|No|String|Used to provide the initial code in the input panel. It overrides the default behaviour, which is to use the content of the `target` element.|`"identity(1)"`|
-|`onChange`|No|Function|This is called with the _pre-compiled_ text from the input window whenever this text is changed. This can be used for updating the URL with a new query string, for example.|```(code) => window.location.hash = URI.encode(code)```|
-|`ramdaScript`|Yes|Object - see below|A script description object used to defined where Ramda is sourced and how it is globally exposed|```{ src : '//cdn.jsdelivr.net/ramda/latest/ramda.min.js',global : 'R'}```|
-|`scripts`|No|Array of Objects - see below|A list of script description objects used to defined where other interesting libraries are sourced and how it is globally exposed|```[{src:'//wzrd.in/standalone/sanctuary@latest',global: 'sanctuary',exposeAs : 'S'}]```|
+<table>
+  <thead>
+    <tr>
+      <th>Key</th>
+      <th>Required</th>
+      <th>Type</th>
+      <th>Description</th>
+      <th>Example</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`apiURL`</td>
+      <td>Yes<td>
+      <td>String</td>
+      <td>A path to a [Google url-shortener]( https://developers.google.com/url-shortener/ ) service endpoint - this will require a specific API key, details [here](https://developers.google.com/url-shortener/v1/getting_started)</td>
+      <td>`'https://www.googleapis.com/urlshortener/v1/url?key=APIKEY'`</td>
+    </tr>
+    <tr>
+      <td>`returnUrl`</td>
+      <td>Yes</td>
+      <td>String</td>
+      <td>A URL (minus query string) that will be used with the url-shortening service to indicate where a sharable link will take user-agents. The current query string will be appended to this. This idea here is that you can have a REPL at `http://your-ramda-repl.com#<code>` and have the share feature redirect to `http://ramdajs.com/repl#<code>` should you wish.</td>
+      <td>
+        <pre lang="js">
+          "http://ramdajs.com/repl/"
+        </pre>
+      </td>
+    </tr>
+    <tr>
+      <td>`initialValue`</td>
+      <td>No</td>
+      <td>String</td>
+      <td>Used to provide the initial code in the input panel. It overrides the default behaviour, which is to use the content of the `target` element.</td>
+      <td>
+        <pre lang="js">
+          "identity(1)"
+        </pre>
+      </td>
+    </tr>
+    <tr>
+      <td>`onChange`</td>
+      <td>No</td>
+      <td>Function</td>
+      <td>This is called with the _pre-compiled_ text from the input window whenever this text is changed. This can be used for updating the URL with a new query string, for example.</td>
+      <td>
+        <pre lang="js">
+          (code) => window.location.hash = URI.encode(code)
+        </pre>
+      </td>
+    </tr>
+    <tr>
+      <td>`ramdaScript`</td>
+      <td>Yes</td>
+      <td>Object - see below</td>
+      <td>A script description object used to defined where Ramda is sourced and how it is globally exposed</td>
+      <td>
+        <pre lang="js">
+          {
+            src    : "//cdn.jsdelivr.net/ramda/latest/ramda.min.js",
+            global : "R"
+          }
+        </pre>
+      </td>
+    </tr>
+    <tr>
+      <td>`scripts`</td>
+      <td>No</td>
+      <td>Array of Objects - see below</td>
+      <td>A list of script description objects used to defined where other interesting libraries are sourced and how it is globally exposed</td>
+      <td>
+        <pre lang="js">
+          [
+            {
+              src      :'//wzrd.in/standalone/sanctuary@latest',
+              global   : 'sanctuary',
+              exposeAs : 'S'
+            }
+          ]
+        </pre>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 
 The keys `ramdaScript` and `scripts` are used to organise the dynamically loaded scripts that will be available to the REPL, such as `ramda`, `ramda-sanctuary` and `ramda-fantasy`. Ramda is loaded first, as it is presumed that the other libraries will require it to be present before they can be included.
 
@@ -52,14 +129,67 @@ Organising the scripts includes providing a reference to a URL where the script 
 
 How the dynamically loaded scripts are made available can defined using objects with the following keys:
 
-|Key|Required|Type|Description|Example|
-|---|--------|----|-----------|-------|
-|`src` |Yes|String|A URL referencing a JavaScript file|`//cdn.jsdelivr.net/ramda/latest/ramda.min.js`|
-|`global`|Yes if `exposeAs` or `expose` are used | String | A name of a global the the script will introduce|`R`|
-|`exposeAs`|No|String|The name of a global that will act as an alias to the global introduced by the script|`RAMDA`|
-|`expose`|No|Array of Strings|A list of method names on the `global` that you wish to expose globally. **Given this list is not provided all methods found on the `global` will be exposed**|```['identity', 'map', 'filter']```|
-
----
+<table>
+  <thead>
+    <tr>
+      <th>Key</th>
+      <th>Required</th>
+      <th>Type</th>
+      <th>Description</th>
+      <th>Example</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`src` </td>
+      <td>Yes</td>
+      <td>String</td>
+      <td>A URL referencing a JavaScript file</td>
+      <td>
+        <pre lang="js">
+           "//cdn.jsdelivr.net/ramda/latest/ramda.min.js"
+        </pre>
+      </td>
+    </tr>
+    <tr>
+      <td>`global`</td>
+      <td>Yes if `exposeAs` or `expose` are used </td>
+      <td> String </td>
+      <td> A name of a global the the script will introduce</td>
+      <td>
+        <pre lang="js">
+          "R"
+        </pre>
+      </td>
+    </tr>
+    <tr>
+      <td>`exposeAs`</td>
+      <td>No</td>
+      <td>String</td>
+      <td>The name of a global that will act as an alias to the global introduced by the script</td>
+      <td>
+        <pre lang="js">
+          "RAMDA"
+        </pre>
+      </td>
+    </tr>
+    <tr>
+      <td>`expose`</td>
+      <td>No</td>
+      <td>Array of Strings</td>
+      <td>A list of method names on the `global` that you wish to expose globally. **Given this list is not provided all methods found on the `global` will be exposed**</td>
+      <td>
+        <pre lang="js">
+          [
+            "identity",
+            "map",
+            "filter"
+          ]
+        </pre>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 ### Development
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ RamdaREPL will do the following operations with respect to the target DOM Node:
       <td>A URL (minus query string) that will be used with the url-shortening service to indicate where a sharable link will take user-agents. The current query string will be appended to this. This idea here is that you can have a REPL at `http://your-ramda-repl.com#<code>` and have the share feature redirect to `http://ramdajs.com/repl#<code>` should you wish.</td>
       <td>
         <pre lang="js">
-          "http://ramdajs.com/repl/"
+"http://ramdajs.com/repl/"
         </pre>
       </td>
     </tr>
@@ -73,7 +73,7 @@ RamdaREPL will do the following operations with respect to the target DOM Node:
       <td>Used to provide the initial code in the input panel. It overrides the default behaviour, which is to use the content of the `target` element.</td>
       <td>
         <pre lang="js">
-          "identity(1)"
+"identity(1)"
         </pre>
       </td>
     </tr>
@@ -84,7 +84,7 @@ RamdaREPL will do the following operations with respect to the target DOM Node:
       <td>This is called with the _pre-compiled_ text from the input window whenever this text is changed. This can be used for updating the URL with a new query string, for example.</td>
       <td>
         <pre lang="js">
-          (code) => window.location.hash = URI.encode(code)
+(code) => window.location.hash = URI.encode(code)
         </pre>
       </td>
     </tr>
@@ -95,10 +95,10 @@ RamdaREPL will do the following operations with respect to the target DOM Node:
       <td>A script description object used to defined where Ramda is sourced and how it is globally exposed</td>
       <td>
         <pre lang="js">
-          {
-            src    : "//cdn.jsdelivr.net/ramda/latest/ramda.min.js",
-            global : "R"
-          }
+{
+  src    : "//cdn.jsdelivr.net/ramda/latest/ramda.min.js",
+  global : "R"
+}
         </pre>
       </td>
     </tr>
@@ -109,13 +109,13 @@ RamdaREPL will do the following operations with respect to the target DOM Node:
       <td>A list of script description objects used to defined where other interesting libraries are sourced and how it is globally exposed</td>
       <td>
         <pre lang="js">
-          [
-            {
-              src      :'//wzrd.in/standalone/sanctuary@latest',
-              global   : 'sanctuary',
-              exposeAs : 'S'
-            }
-          ]
+[
+  {
+    src      :'//wzrd.in/standalone/sanctuary@latest',
+    global   : 'sanctuary',
+    exposeAs : 'S'
+  }
+]
         </pre>
       </td>
     </tr>
@@ -147,7 +147,7 @@ How the dynamically loaded scripts are made available can defined using objects 
       <td>A URL referencing a JavaScript file</td>
       <td>
         <pre lang="js">
-           "//cdn.jsdelivr.net/ramda/latest/ramda.min.js"
+"//cdn.jsdelivr.net/ramda/latest/ramda.min.js"
         </pre>
       </td>
     </tr>
@@ -158,7 +158,7 @@ How the dynamically loaded scripts are made available can defined using objects 
       <td> A name of a global the the script will introduce</td>
       <td>
         <pre lang="js">
-          "R"
+"R"
         </pre>
       </td>
     </tr>
@@ -169,7 +169,7 @@ How the dynamically loaded scripts are made available can defined using objects 
       <td>The name of a global that will act as an alias to the global introduced by the script</td>
       <td>
         <pre lang="js">
-          "RAMDA"
+"RAMDA"
         </pre>
       </td>
     </tr>
@@ -180,11 +180,11 @@ How the dynamically loaded scripts are made available can defined using objects 
       <td>A list of method names on the `global` that you wish to expose globally. **Given this list is not provided all methods found on the `global` will be exposed**</td>
       <td>
         <pre lang="js">
-          [
-            "identity",
-            "map",
-            "filter"
-          ]
+[
+  "identity",
+  "map",
+  "filter"
+]
         </pre>
       </td>
     </tr>

--- a/README.md
+++ b/README.md
@@ -7,6 +7,99 @@ A repl (read-eval-print-loop) for [Ramda](http://ramdajs.com/)
 
 ---
 
+### Usage
+
+[dist/bundle.js](dist/bundle.js) will expose a global function called `ramdaRepl`.
+
+`ramdaRepl` takes two arguments (details to follow) and will immediately attempt to instantiate itself in the DOM.
+
+```js
+ramdaRepl(target, config)
+```
+
+#### target
+
+`target` is a reference to a DOM Node, such as you would get from `document.querySelector`:
+
+```js
+var target = document.querySelector('#my-text-area');
+```
+
+RamdaREPL will do the following operations relating with respect to the target DOM Node:
+
+- it will hide the target node
+- it will add itself to the DOM as a sibling to the target node
+- it will look for text within the target node, adding the text to its input panel when it appears (note that this can be overridden in certain circumstances).
+
+#### config
+
+`config` is a regular JavaScript object.
+
+```javascript
+
+var config = {
+
+  apiUrl: 'https://www.googleapis.com/urlshortener/v1/url?key=AIzaSyDhbAvT5JqkxFPkoeezJp19-S_mAJudxyk',
+  returnUrl: 'http://ramdajs.com/repl/',
+
+  // If unset, initialValue will use the value or textcontent of the
+  // target element.
+  initialValue: URI.decode(window.location.hash).substring(2),
+
+  // Called with the pre-compiled content
+  onChange : function(code) {
+    window.location.hash = '?' + URI.encode(code);
+  },
+
+  // The following config defines scripts that will be dynamically
+  // loaded upon creating the REPL. Each has the following properties:
+  //
+  // src      - The source of the script, a URL
+  // global   - (Optional) a name of a global that the script introduces
+  // exposeAs - (Optional) a name that can alias the global
+  // expose   - (Optional) a list of methods to expose globally
+
+  // Required.
+  // As ramda may be a dependency for other scripts, it will
+  // be intentionally loaded before any other script.
+  ramdaScript: {
+    src    : ramdaUrl,
+    global : 'R'
+  },
+
+  // Optional.
+  // Here we can declare a list of libraries that we wish to have
+  // loaded and exposed in the repl.
+  scripts: [
+    {
+      src      : '//wzrd.in/standalone/sanctuary@latest',
+      global   : 'sanctuary',
+      exposeAs : 'S'
+    },
+    {
+      src    : '//wzrd.in/standalone/ramda-fantasy@latest',
+      global : 'ramdaFantasy',
+      expose : [
+        'Either',
+        'Future',
+        'Identity',
+        'IO',
+        'lift2',
+        'lift3',
+        'Maybe',
+        'Tuple',
+        'Reader'
+      ]
+    }
+  ]
+
+};
+
+```
+
+
+---
+
 ### Development
 
 You will find a collection of [npm run *](https://docs.npmjs.com/cli/run-script) scripts in [package.json](package.json):

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ ramdaRepl(target, config)
 var target = document.querySelector('#my-text-area');
 ```
 
-RamdaREPL will do the following operations relating with respect to the target DOM Node:
+RamdaREPL will do the following operations with respect to the target DOM Node:
 
 - it will hide the target node
 - it will add itself to the DOM as a sibling to the target node
@@ -38,12 +38,13 @@ RamdaREPL will do the following operations relating with respect to the target D
 `config` is a regular JavaScript object.
 
 |Key|Required|Type|Description|Example|
-|`apiURL`|Yes|String|A path to a [Google url-shortener]( https://developers.google.com/url-shortener/ ) service endpoint - this will require a specific API key, details [here](https://developers.google.com/url-shortener/v1/getting_started) |'https://www.googleapis.com/urlshortener/v1/url?key=<API-KEY>'|
-|`returnUrl`|Yes|String|A URL (minus query string) that will be used with the url-shortening service to indicate where a sharable link will take user-agents. The current query string will be appended to this. This idea here is that you can have a REPL at `http://your-ramda-repl.com#<code>` and have the share feature redirect to `http://ramdajs.com/repl#<code>` should you wish.|'http://ramdajs.com/repl/'|
-|`initialValue`|No|String|Used to provide the initial code in the input panel. It overrides the default behaviour, which is to use the content of the `target` element.|"identity(1)"|
-|`onChange`|No|Function|This is called with the _pre-compiled_ text from the input window whenever this text is changed. This can be used for updating the URL with a new query string, for example.|`(code) => window.location.hash = URI.encode(code)`|
-|`ramdaScript`|Yes|Object - see below|A script description object used to defined where Ramda is sourced and how it is globally exposed|`{ src : '//cdn.jsdelivr.net/ramda/latest/ramda.min.js', global : 'R' }`|
-|`scripts`|No|Array of Objects - see below|A list of script description objects used to defined where other interesting libraries are sourced and how it is globally exposed|`[{src:'//wzrd.in/standalone/sanctuary@latest', global: 'sanctuary', exposeAs : 'S'}]|
+|---|--------|----|-----------|-------|
+|`apiURL`|Yes|String|A path to a [Google url-shortener]( https://developers.google.com/url-shortener/ ) service endpoint - this will require a specific API key, details [here](https://developers.google.com/url-shortener/v1/getting_started)|`'https://www.googleapis.com/urlshortener/v1/url?key=APIKEY'`|
+|`returnUrl`|Yes|String|A URL (minus query string) that will be used with the url-shortening service to indicate where a sharable link will take user-agents. The current query string will be appended to this. This idea here is that you can have a REPL at `http://your-ramda-repl.com#<code>` and have the share feature redirect to `http://ramdajs.com/repl#<code>` should you wish.|`'http://ramdajs.com/repl/'`|
+|`initialValue`|No|String|Used to provide the initial code in the input panel. It overrides the default behaviour, which is to use the content of the `target` element.|`"identity(1)"`|
+|`onChange`|No|Function|This is called with the _pre-compiled_ text from the input window whenever this text is changed. This can be used for updating the URL with a new query string, for example.|```(code) => window.location.hash = URI.encode(code)```|
+|`ramdaScript`|Yes|Object - see below|A script description object used to defined where Ramda is sourced and how it is globally exposed|```{ src : '//cdn.jsdelivr.net/ramda/latest/ramda.min.js',global : 'R'}```|
+|`scripts`|No|Array of Objects - see below|A list of script description objects used to defined where other interesting libraries are sourced and how it is globally exposed|```[{src:'//wzrd.in/standalone/sanctuary@latest',global: 'sanctuary',exposeAs : 'S'}]```|
 
 The keys `ramdaScript` and `scripts` are used to organise the dynamically loaded scripts that will be available to the REPL, such as `ramda`, `ramda-sanctuary` and `ramda-fantasy`. Ramda is loaded first, as it is presumed that the other libraries will require it to be present before they can be included.
 
@@ -51,11 +52,12 @@ Organising the scripts includes providing a reference to a URL where the script 
 
 How the dynamically loaded scripts are made available can defined using objects with the following keys:
 
-| Key | Required | Type | Description | Example
-|`src` | Yes | String | A URL referencing a JavaScript file | `//cdn.jsdelivr.net/ramda/latest/ramda.min.js` |
-| `global` | Yes if `exposeAs` or `expose` are used | String | A name of a global the the script will introduce | `R` |
-| `exposeAs` | No | String | The name of a global that will act as an alias to the global introduced by the script | `RAMDA` |
-| `expose` | No | Array of Strings | A list of method names on the `global` that you wish to expose globally. *Given this list is not provided all methods found on the `global` will be exposed*  | `[identity, map, filter]` |
+|Key|Required|Type|Description|Example|
+|---|--------|----|-----------|-------|
+|`src` |Yes|String|A URL referencing a JavaScript file|`//cdn.jsdelivr.net/ramda/latest/ramda.min.js`|
+|`global`|Yes if `exposeAs` or `expose` are used | String | A name of a global the the script will introduce|`R`|
+|`exposeAs`|No|String|The name of a global that will act as an alias to the global introduced by the script|`RAMDA`|
+|`expose`|No|Array of Strings|A list of method names on the `global` that you wish to expose globally. **Given this list is not provided all methods found on the `global` will be exposed**|```['identity', 'map', 'filter']```|
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ RamdaREPL will do the following operations with respect to the target DOM Node:
       <td>`apiURL`</td>
       <td>Yes</td>
       <td>String</td>
-      <td>A path to a [Google url-shortener]( https://developers.google.com/url-shortener/ ) service endpoint - this will require a specific API key, details [here](https://developers.google.com/url-shortener/v1/getting_started)</td>
+      <td>A path to a [https://developers.google.com/url-shortener/](Google url-shortener) service endpoint - this will require a specific API key, details [here](https://developers.google.com/url-shortener/v1/getting_started)</td>
       <td>
         <pre lang="js">
 "https://www.googleapis.com/urlshortener/v1/url?key=APIKEY"
@@ -63,7 +63,7 @@ RamdaREPL will do the following operations with respect to the target DOM Node:
       <td>`returnUrl`</td>
       <td>Yes</td>
       <td>String</td>
-      <td>A URL (minus query string) that will be used with the url-shortening service to indicate where a sharable link will take user-agents. The current query string will be appended to this. This idea here is that you can have a REPL at `http://your-ramda-repl.com#<code>` and have the share feature redirect to `http://ramdajs.com/repl#<code>` should you wish.</td>
+      <td>A URL (minus query string) that will be used with the url-shortening service to indicate where a sharable link will take user-agents. The current query string will be appended to this. This idea here is that you can have a REPL at `http://your-ramda-repl.com#code` and have the share feature redirect to `http://ramdajs.com/repl#code` should you wish.</tdw>
       <td>
         <pre lang="js">
 "http://ramdajs.com/repl/"


### PR DESCRIPTION
Closes #31 

This documents the API such as it is at present.

As github markdown does not have a way to achive nicely formatted code examples in tables (that I could find), I resorted to using _HyperText Markup Language_.

Here is a link to [how it looks](https://github.com/craigdallimore/repl/blob/update-docs/README.md).
