### PR TITLE
Bump version to 1.1.0 and fixed repo url

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ramda-repl",
   "description": "Ramda + Ramda Fantasy + Sanctuary REPL",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "dependencies": {
     "babel-core": "6.16.0",
     "babel-polyfill": "6.16.0",
@@ -24,7 +24,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "git://github.com/ramda/ramda.github.io.git"
+    "url": "git://github.com/ramda/ramda-repl.git"
   },
   "scripts": {
     "build-js": "browserify -t [ babelify ] ./lib/js/main.js -o ./dist/bundle.js",


### PR DESCRIPTION
- Starting to use versioning because ramda.github.io depends on it

See https://github.com/ramda/ramda.github.io/pull/190

@buzzdecafe @MattMS @craigdallimore 