### PR TITLE
Use verbose error message when redeclaring an imported function (#54)

### DIFF
--- a/lib/js/input-panel.js
+++ b/lib/js/input-panel.js
@@ -28,13 +28,18 @@ const transformConfig = {
 
 const ramdaStr = `const {${R.keys(R).join(',')}} = R;`;
 const evalSource = R.compose(R.toString, eval); // eslint-disable-line no-eval
+const errRedeclaringRamdaFn = new RegExp(`^ramda: Duplicate declaration "(${R.keys(R).join('|')})"`);
 
 const formatCode = code => evalSource(code)
                               .replace('"use strict"', '')
 
 const formatError = err => err.message
                               .replace(ramdaStr, '')
-                              .replace(/(?=\d).*(?=\|)/g, a => Number(a.trim()) - 1);
+                              .replace(/(?=\d).*(?=\|)/g, a => Number(a.trim()) - 1)
+                              .replace(
+                                errRedeclaringRamdaFn,
+                                'ramda: Cannot redeclare "$1" that has already been imported from Ramda'
+                              );
 
 function compile(input, options) {
 

--- a/test/input-panel.test.js
+++ b/test/input-panel.test.js
@@ -100,6 +100,25 @@ describe('Input panel', function() {
 
   });
 
+  it('should set verbose error message if a compile fails when trying to redeclaring an imported function', function() {
+
+    const input = bindInputPanel({
+      input: inputEl,
+      evalError: errMsgEl,
+      output,
+      delay: 0
+    });
+
+    const fn = 'test';
+    input.setValue(`var ${fn};`);
+
+    clock.tick(10); // debounce
+
+    sinon.assert.notCalled(output.setValue);
+    assert.equal(`ramda: Cannot redeclare "${fn}" that has already been imported from Ramda`, errMsgEl.textContent);
+
+  });
+
   it('clears error messages before a compile', function() {
 
     errMsgEl.textContent = '♈';

--- a/test/pretty.test.js
+++ b/test/pretty.test.js
@@ -19,7 +19,7 @@ describe('Clicking the "pretty" button', function() {
   it('should instruct the "output" CodeMirror to reformat the text', function() {
 
     const unformattedCode = "['a', 'b', 'c,']";
-    const formattedCode = `[\n    "a",\n    "b",\n    "c,"\n]`;
+    const formattedCode = '[\n    "a",\n    "b",\n    "c,"\n]';
 
     output = {
       setValue : sinon.spy(),


### PR DESCRIPTION
When a user declares a variable that conflicts with one of Ramda's imported functions, the error message will now say:
```
ramda: Cannot redeclare "${ramdaFn}" that has already been imported from Ramda
```

This will close issue #54.

<br/>

I think the changes are good to go but two tests are failing locally on `master` and this branch.Not sure if you or TravisCI will have the same issues:

<img width="977" alt="screen shot 2018-03-30 at 13 21 34" src="https://user-images.githubusercontent.com/2585460/38146775-6e6e24fa-341d-11e8-97b1-daf103b539f0.png">
