### PR TITLE
Fix failing tests (#56)

### DIFF
--- a/test/input-panel.test.js
+++ b/test/input-panel.test.js
@@ -2,14 +2,17 @@ import assert from 'assert';
 import jsdom from 'jsdom';
 import R from 'ramda';
 import sinon from 'sinon';
-import bindInputPanel from '../lib/js/input-panel';
+
+// Provide a way to push time forwards (as the input is debounced).
+const clock = sinon.useFakeTimers();
+const bindInputPanel = require('../lib/js/input-panel').default;
+
 
 describe('Input panel', function() {
 
   let errMsgEl,
     inputEl,
-    output,
-    clock;
+    output;
 
   beforeEach(function() {
 
@@ -34,9 +37,6 @@ describe('Input panel', function() {
     // these to exist.
     // https://github.com/tmpvar/jsdom/issues/317
     doc.body.createTextRange = () => doc.querySelector('.mock');
-
-    // Provide a way to push time forwards (as the input is debounced).
-    clock = sinon.useFakeTimers();
 
     errMsgEl = doc.querySelector('.err-msg');
     inputEl = doc.querySelector('.input');


### PR DESCRIPTION
As reported in #55, two tests have been failing when running locally. Investigation has shown that the `change` event handler in `bindInputPanel` is not called. Despite the tests waiting twice the debouncing delay, the debounced function is not called.

The root cause of the test failures is the fake timers are not applying to the `now()` call in the `debounce` library. Based on [the docs](http://sinonjs.org/releases/v1.17.7/fake-timers/) for fake timers, calling `sinon.useFakeTimers()` should:
> Starts the clock at the UNIX epoch (timestamp of 0).

After calling `clock.tick(ms)` we should see `ms`, but instead we get the current `timestamp` (below highlighted variable on mid left):
    
<img width="938" alt="screen shot 2018-04-15 at 23 43 08" src="https://user-images.githubusercontent.com/2585460/38789323-88dc9096-4107-11e8-8260-c320ab19e8be.png">

Changing the order of the imports ensures that `debounce` and `date-now` use the fake timers, and the tests pass. With the changes in this PR, notice how the `timestamp` is our value for `clock.tick(ms)`:

<img width="928" alt="screen shot 2018-04-15 at 23 57 12" src="https://user-images.githubusercontent.com/2585460/38789530-d6c97250-4108-11e8-9898-6b7b4ea5353c.png">

Those failing tests pass:
<img width="746" alt="screen shot 2018-04-15 at 23 59 03" src="https://user-images.githubusercontent.com/2585460/38789559-07e8fc52-4109-11e8-8c8a-44fa4963d95b.png">
