### PR TITLE
Add CodeMirror commenting addon and Sublime keymap

### DIFF
--- a/lib/js/codemirror/codemirror.js
+++ b/lib/js/codemirror/codemirror.js
@@ -2,6 +2,8 @@ import CodeMirror from 'codemirror';
 import 'codemirror/addon/edit/closebrackets';
 import 'codemirror/addon/hint/show-hint';
 import 'codemirror/addon/hint/javascript-hint';
+import 'codemirror/addon/comment/comment'
+import 'codemirror/keymap/sublime';
 import 'codemirror/mode/javascript/javascript';
 
 export default CodeMirror;

--- a/lib/js/input-panel.js
+++ b/lib/js/input-panel.js
@@ -15,7 +15,8 @@ const inputConfig = R.merge(codeMirrorConfig, {
   },
   autofocus: true,
   autoCloseBrackets: true,
-  historyEventDelay: 2000
+  historyEventDelay: 2000,
+  keyMap: 'sublime'
 });
 
 const transformConfig = {


### PR DESCRIPTION
** DO NOT MERGE YET **

@CrossEye 

This PR is in reference to [issue](https://github.com/ramda/ramda.github.io/issues/213#issuecomment-391381886)

This is to add the functionality to comment code (line/block) within the REPL. 

I imported the comment addon from CodeMirror along with the Sublime keymap that will enable commenting of code with `CMD/CTRL + /`.

I have been unable to get the functionality to work, however. I used the [graphql/graphiql REPL](https://github.com/graphql/graphiql/blob/master/src/components/QueryEditor.js) as a guide as it uses CodeMirror in a similar style and has the commenting functionality.

My only guess after hitting a wall with it is that what the Ramda is doing to process the input is ignoring/blocking the commenting functionality.

I hope someone is able to chip in and help get this feature added. I'm happy to help in any way if there is something that I am obviously missing.

Thanks!