### PR TITLE
Support NaN undefined Infinity in console.log output

### DIFF
--- a/lib/js/logger.js
+++ b/lib/js/logger.js
@@ -6,6 +6,27 @@ const reporter = {};
 let consoleLogElement,
   consoleRef;
 
+const valueReplacer = (key, value) => {
+  if (value === undefined) {
+    return `__${undefined}__`
+  }
+  if (typeof value === 'number' && (isNaN(value) || !isFinite(value))) {
+    return `__${value}__`;
+  }
+  return value;
+}
+
+const replaceTempValues = (str = '') => str
+  .replace(/"__undefined__"/g, 'undefined')
+  .replace(/"__NaN__"/g, 'NaN')
+  .replace(/"__Infinity__"/g, 'Infinity')
+  .replace(/"__-Infinity__"/g, '-Infinity');
+
+const stringify = R.compose(
+  replaceTempValues,
+  R.flip(R.curryN(2, JSON.stringify))(valueReplacer)
+)
+
 internals.buffer = [];
 
 internals.flush = function flush() {
@@ -17,7 +38,7 @@ internals.logMethods = ['log', 'info', 'debug'];
 internals.prepLogs = R.cond([
   [R.is(String), R.identity],
   [R.is(Function), R.toString],
-  [R.T, JSON.stringify]
+  [R.T, stringify]
 ]);
 
 internals.intercept = function(method) {

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -136,6 +136,36 @@ describe('reporter', function() {
 
         });
 
+        it('will display stringified array with: undefined, NaN, Infinity ', function() {
+
+          reporter.main({
+            consoleLogElement : logEl,
+            consoleRef : consoleMock
+          });
+
+          const arr = [undefined, NaN, Infinity, -Infinity];
+
+          consoleMock[method](arr);
+
+          assert.equal('[undefined,NaN,Infinity,-Infinity]', logEl.textContent);
+
+        });
+
+        it('will display stringified object with: undefined, NaN, Infinity ', function() {
+
+          reporter.main({
+            consoleLogElement : logEl,
+            consoleRef : consoleMock
+          });
+
+          const obj = {a: undefined, b: NaN, c:Infinity, d:-Infinity};
+
+          consoleMock[method](obj);
+
+          assert.equal('{"a":undefined,"b":NaN,"c":Infinity,"d":-Infinity}', logEl.textContent);
+
+        });
+
       });
 
     });


### PR DESCRIPTION
Currently the `console.log` in the Ramda Repl displays `undefined` as `null` in arrays, and doesn't display object properties that have a value of `undefined`. The global properties `NaN` and `Infinity` are also displayed as `null` in arrays and objects. 

This has caught me out a few times - so I thought I'd have a go at putting in a fix! Will close #49

**Example of problem from the Repl**
```
console.log(
  [null, undefined, NaN, Infinity, -Infinity], 
  { a: null, b:undefined, c:NaN, d:Infinity, e:-Infinity}
)  
[null,null,null,null,null]
{"a":null,"c":null,"d":null,"e":null}
```
I added a `replacer` function to the `JSON.stringify` method of `logger.js` - which covers common properties that `JSON.stringify` doesn't support. Updated the tests, and all passing (although two unrelated tests intermittently fail - this this is being addressed in PR #57 I think)

![image](https://user-images.githubusercontent.com/15702512/52917171-1fdab200-32e0-11e9-93a1-2dd7b498f68c.png)

